### PR TITLE
test correction

### DIFF
--- a/src/socket.erl
+++ b/src/socket.erl
@@ -25,10 +25,10 @@
 
 -define(TCP_LISTEN_OPTIONS,[  {active, false},
                               {backlog, 30},
+                              {ip,{0,0,0,0}},
                               {keepalive, true},
                               {packet, line},
-                              {reuseaddr, true},
-															{ip,{0,0,0,0}}]).
+                              {reuseaddr, true}]).
 -define(TCP_CONNECT_OPTIONS,[ {active, false},
                               {packet, line}]).
 -define(SSL_LISTEN_OPTIONS, [ {active, false},
@@ -508,6 +508,7 @@ option_test_() ->
 		fun() ->
 			?assertMatch([list,{active, true},
 			                   {backlog, 30},
+			                   {ip,{0,0,0,0}},
 			                   {keepalive, true},
 			                   {packet, 2},
 			                   {reuseaddr, true}],


### PR DESCRIPTION
My last commit broke the socket module tests, now they are passing. The TCP_LISTEN_OPTIONS in the tests weren't expecting the ip option.
