### PR TITLE
client: Let Date header comply better to RFC 5322 by using 2-digit time components

### DIFF
--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -83,7 +83,7 @@ rfc5322_timestamp() ->
 	NDay = calendar:day_of_the_week(Year, Month, Day),
 	DoW = lists:nth(NDay, ?DAYS),
 	MoY = lists:nth(Month, ?MONTHS),
-	io_lib:format("~s, ~b ~s ~b ~b:~b:~b ~s", [DoW, Day, MoY, Year, Hour, Minute, Second, zone()]).
+	io_lib:format("~s, ~b ~s ~b ~2..0w:~2..0w:~2..0w ~s", [DoW, Day, MoY, Year, Hour, Minute, Second, zone()]).
 
 %% @doc Calculate the current timezone and format it like -0400. Borrowed from YAWS.
 zone() ->


### PR DESCRIPTION
RFC 5322 section 3.3
