### PR TITLE
RFC allows up to 254 character from addresses

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -635,7 +635,7 @@ parse_encoded_address(<<>>, Acc, {_Quotes, false}) ->
 	{list_to_binary(lists:reverse(Acc)), <<>>};
 parse_encoded_address(<<>>, _Acc, {_Quotes, true}) ->
 	error; % began with angle brackets but didn't end with them
-parse_encoded_address(_, Acc, _) when length(Acc) > 254 ->
+parse_encoded_address(_, Acc, _) when length(Acc) > 320 ->
 	error; % too long
 parse_encoded_address(<<"\\", Tail/binary>>, Acc, Flags) ->
 	<<H, NewTail/binary>> = Tail,


### PR DESCRIPTION
We noticed that mixpanel can't send messages to our gen_smtp server, and traced it down to length. This patch upgrades the parse limit from 129 chars to 254.
