### PR TITLE
Make clear that gen_smtp is listening

### DIFF
--- a/src/gen_smtp_server.erl
+++ b/src/gen_smtp_server.erl
@@ -137,7 +137,7 @@ init([Module, Configurations]) ->
 					Protocol = proplists:get_value(protocol, NewConfig),
 					SessionOptions = proplists:get_value(sessionoptions, NewConfig, []),
 					error_logger:info_msg("~p starting at ~p~n", [?MODULE, node()]),
-					error_logger:info_msg("listening on ~p:~p via ~p~n", [IP, Port, Protocol]),
+					error_logger:info_msg("~p listening on ~p:~p via ~p~n", [?MODULE, IP, Port, Protocol]),
 					process_flag(trap_exit, true),
 					ListenOptions = [binary, {ip, IP}, Family],
 					case socket:listen(Protocol, Port, ListenOptions) of


### PR DESCRIPTION
This patch adds the ?MODULE in front of the message that tells where gen_smtp is listening.

In Zotonic, it is confusing that it just says "listening on 2525" which lets users think that the web server is running on that port.

So with this patch, the message will read:

```
11:10:20.417 [info] gen_smtp_server listening on {0,0,0,0}:2525 via tcp
```
