### PR TITLE
Use lager:debug instead of io:format.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,12 @@
 %% -*- mode: erlang; -*-
 
-{erl_opts, [fail_on_warning, debug_info, warn_unused_vars, warn_unused_import, warn_exported_vars]}.
+{erl_opts, [fail_on_warning,
+            debug_info,
+            warn_unused_vars,
+            warn_unused_import,
+            warn_exported_vars,
+            {parse_transform, lager_transform}]}.
+
 {cover_enabled, true}.
+{deps, [{lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "2.0.0"}}}]}.
 {cover_print_enabled, true}.

--- a/rebar.test.config
+++ b/rebar.test.config
@@ -1,10 +1,16 @@
 %% -*- mode: erlang; -*-
 
-{erl_opts, [fail_on_warning, debug_info, warn_unused_vars, warn_unused_import, warn_exported_vars]}.
+{erl_opts, [fail_on_warning,
+            debug_info,
+            warn_unused_vars,
+            warn_unused_import,
+            warn_exported_vars,
+            {parse_transform, lager_transform}]}.
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 
 {deps,
  [
-  {eiconv, ".*", {git, "git://github.com/zotonic/eiconv.git", {branch, "master"}}}
+  {eiconv, ".*", {git, "git://github.com/zotonic/eiconv.git", {branch, "master"}}},
+  {lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "2.0.0"}}}
  ]}.

--- a/src/gen_smtp_server.erl
+++ b/src/gen_smtp_server.erl
@@ -184,7 +184,7 @@ handle_info({inet_async, ListenPort,_, {ok, ClientAcceptSocket}},
 				end || L <- Listeners]),
 		{ok, ClientSocket} = socket:handle_inet_async(Listener#listener.socket, ClientAcceptSocket, Listener#listener.listenoptions),
 		%% New client connected
-		% io:format("new client connection.~n", []),
+		% lager:debug("new client connection.~n", []),
 		Sessions = case gen_smtp_server_session:start(ClientSocket, Module, [{hostname, Listener#listener.hostname}, {sessioncount, length(CurSessions) + 1} | Listener#listener.sessionoptions]) of
 			{ok, Pid} ->
 				link(Pid),
@@ -203,11 +203,11 @@ handle_info({'EXIT', From, Reason}, State) ->
 		true ->
 			{noreply, State#state{sessions = lists:delete(From, State#state.sessions)}};
 		false ->
-			io:format("process ~p exited with reason ~p~n", [From, Reason]),
+			lager:debug("process ~p exited with reason ~p~n", [From, Reason]),
 			{noreply, State}
 	end;
 handle_info({inet_async, ListenSocket, _, {error, econnaborted}}, State) ->
-	io:format("Client terminated connection with econnaborted~n"),
+	lager:debug("Client terminated connection with econnaborted~n"),
 	socket:begin_inet_async(ListenSocket),
 	{noreply, State};
 handle_info({inet_async, _ListenSocket,_, Error}, State) ->
@@ -219,7 +219,7 @@ handle_info(_Info, State) ->
 %% @hidden
 -spec terminate(Reason :: any(), State :: #state{}) -> 'ok'.
 terminate(Reason, State) ->
-	io:format("Terminating due to ~p~n", [Reason]),
+	lager:debug("Terminating due to ~p~n", [Reason]),
 	lists:foreach(fun(#listener{socket=S}) -> catch socket:close(S) end, State#state.listeners),
 	ok.
 

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -144,7 +144,7 @@ handle_info({receive_data, {error, size_exceeded}}, #state{socket = Socket, read
 	{noreply, State#state{readmessage = false, envelope = #envelope{}}, ?TIMEOUT};
 handle_info({receive_data, {error, bare_newline}}, #state{socket = Socket, readmessage = true} = State) ->
 	socket:send(Socket, "451 Bare newline detected\r\n"),
-	io:format("bare newline detected: ~p~n", [self()]),
+	lager:debug("bare newline detected: ~p~n", [self()]),
 	socket:active_once(Socket),
 	{noreply, State#state{readmessage = false, envelope = #envelope{}}, ?TIMEOUT};
 handle_info({receive_data, Body, Rest}, #state{socket = Socket, readmessage = true, envelope = Env, module=Module,
@@ -216,7 +216,7 @@ handle_info(timeout, #state{socket = Socket} = State) ->
 	socket:close(Socket),
 	{stop, normal, State};
 handle_info(Info, State) ->
-	io:format("unhandled info message ~p~n", [Info]),
+	lager:debug("unhandled info message ~p~n", [Info]),
 	{noreply, State}.
 
 %% @hidden
@@ -241,7 +241,7 @@ parse_request(Packet) ->
 	Request = binstr:strip(binstr:strip(binstr:strip(binstr:strip(Packet, right, $\n), right, $\r), right, $\s), left, $\s),
 	case binstr:strchr(Request, $\s) of
 		0 ->
-			% io:format("got a ~s request~n", [Request]),
+			% lager:debug("got a ~s request~n", [Request]),
 			case binstr:to_upper(Request) of
 				<<"QUIT">> = Res -> {Res, <<>>};
 				<<"DATA">> = Res -> {Res, <<>>};
@@ -251,7 +251,7 @@ parse_request(Packet) ->
 		Index ->
 			Verb = binstr:substr(Request, 1, Index - 1),
 			Parameters = binstr:strip(binstr:substr(Request, Index + 1), left, $\s),
-			%io:format("got a ~s request with parameters ~s~n", [Verb, Parameters]),
+            lager:debug("got a ~s request with parameters ~s~n", [Verb, Parameters]),
 			{binstr:to_upper(Verb), Parameters}
 	end.
 
@@ -419,7 +419,7 @@ handle_request({<<"MAIL">>, Args}, #state{socket = Socket, module = Module, enve
 							socket:send(Socket, "501 Bad sender address syntax\r\n"),
 							{ok, State};
 						{ParsedAddress, <<>>} ->
-							%io:format("From address ~s (parsed as ~s)~n", [Address, ParsedAddress]),
+							lager:debug("From address ~s (parsed as ~s)~n", [Address, ParsedAddress]),
 							case Module:handle_MAIL(ParsedAddress, OldCallbackState) of
 								{ok, CallbackState} ->
 									socket:send(Socket, "250 sender Ok\r\n"),
@@ -429,9 +429,9 @@ handle_request({<<"MAIL">>, Args}, #state{socket = Socket, module = Module, enve
 									{ok, State#state{callbackstate = CallbackState}}
 							end;
 						{ParsedAddress, ExtraInfo} ->
-							%io:format("From address ~s (parsed as ~s) with extra info ~s~n", [Address, ParsedAddress, ExtraInfo]),
+							lager:debug("From address ~s (parsed as ~s) with extra info ~s~n", [Address, ParsedAddress, ExtraInfo]),
 							Options = [binstr:to_upper(X) || X <- binstr:split(ExtraInfo, <<" ">>)],
-							%io:format("options are ~p~n", [Options]),
+							lager:debug("options are ~p~n", [Options]),
 							 F = fun(_, {error, Message}) ->
 									 {error, Message};
 								 (<<"SIZE=", Size/binary>>, InnerState) ->
@@ -463,11 +463,11 @@ handle_request({<<"MAIL">>, Args}, #state{socket = Socket, module = Module, enve
 							end,
 							case lists:foldl(F, State, Options) of
 								{error, Message} ->
-									%io:format("error: ~s~n", [Message]),
+									lager:debug("error: ~s~n", [Message]),
 									socket:send(Socket, Message),
 									{ok, State};
 								NewState ->
-									%io:format("OK~n"),
+									lager:debug("OK~n"),
 									case Module:handle_MAIL(ParsedAddress, State#state.callbackstate) of
 										{ok, CallbackState} ->
 											socket:send(Socket, "250 sender Ok\r\n"),
@@ -502,7 +502,7 @@ handle_request({<<"RCPT">>, Args}, #state{socket = Socket, envelope = Envelope, 
 					socket:send(Socket, "501 Bad recipient address syntax\r\n"),
 					{ok, State};
 				{ParsedAddress, <<>>} ->
-					%io:format("To address ~s (parsed as ~s)~n", [Address, ParsedAddress]),
+					lager:debug("To address ~s (parsed as ~s)~n", [Address, ParsedAddress]),
 					case Module:handle_RCPT(ParsedAddress, OldCallbackState) of
 						{ok, CallbackState} ->
 							socket:send(Socket, "250 recipient Ok\r\n"),
@@ -513,7 +513,7 @@ handle_request({<<"RCPT">>, Args}, #state{socket = Socket, envelope = Envelope, 
 					end;
 				{ParsedAddress, ExtraInfo} ->
 					% TODO - are there even any RCPT extensions?
-					io:format("To address ~s (parsed as ~s) with extra info ~s~n", [Address, ParsedAddress, ExtraInfo]),
+					lager:debug("To address ~s (parsed as ~s) with extra info ~s~n", [Address, ParsedAddress, ExtraInfo]),
 					socket:send(Socket, ["555 Unsupported option: ", ExtraInfo, "\r\n"]),
 					{ok, State}
 			end;
@@ -534,7 +534,7 @@ handle_request({<<"DATA">>, <<>>}, #state{socket = Socket, envelope = Envelope} 
 			{ok, State};
 		_Else ->
 			socket:send(Socket, "354 enter mail, end with line containing only '.'\r\n"),
-			%io:format("switching to data read mode~n", []),
+			lager:debug("switching to data read mode~n", []),
 
 			{ok, State#state{readmessage = true}}
 	end;
@@ -589,12 +589,12 @@ handle_request({<<"STARTTLS">>, <<>>}, #state{socket = Socket, module = Module, 
 			% TODO: certfile and keyfile should be at configurable locations
 			case socket:to_ssl_server(Socket, Options2, 5000) of
 				{ok, NewSocket} ->
-					%io:format("SSL negotiation sucessful~n"),
+					lager:debug("SSL negotiation sucessful~n"),
 					{ok, State#state{socket = NewSocket, envelope=undefined,
 							authdata=undefined, waitingauth=false, readmessage=false,
 							tls=true, callbackstate = Module:handle_STARTTLS(OldCallbackState)}};
 				{error, Reason} ->
-					io:format("SSL handshake failed : ~p~n", [Reason]),
+					lager:error("SSL handshake failed : ~p~n", [Reason]),
 					socket:send(Socket, "454 TLS negotiation failed\r\n"),
 					{ok, State}
 			end;
@@ -674,7 +674,7 @@ parse_encoded_address(<<H, Tail/binary>>, Acc, Quotes) ->
 has_extension(Exts, Ext) ->
 	Extension = string:to_upper(Ext),
 	Extensions = [{string:to_upper(X), Y} || {X, Y} <- Exts],
-	%io:format("extensions ~p~n", [Extensions]),
+	lager:debug("extensions ~p~n", [Extensions]),
 	case proplists:get_value(Extension, Extensions) of
 		undefined ->
 			false;
@@ -699,7 +699,7 @@ try_auth(AuthType, Username, Credential, #state{module = Module, socket = Socket
 					{ok, NewState}
 				end;
 		false ->
-			io:format("Please define handle_AUTH/4 in your server module or remove AUTH from your module extensions~n"),
+			lager:debug("Please define handle_AUTH/4 in your server module or remove AUTH from your module extensions~n"),
 			socket:send(Socket, "535 authentication failed (#5.7.1)\r\n"),
 			{ok, NewState}
 	end.
@@ -712,7 +712,7 @@ try_auth(AuthType, Username, Credential, #state{module = Module, socket = Socket
 
 %% @doc a tight loop to receive the message body
 receive_data(_Acc, _Socket, _, Size, MaxSize, Session, _Options) when MaxSize > 0, Size > MaxSize ->
-	io:format("message body size ~B exceeded maximum allowed ~B~n", [Size, MaxSize]),
+	lager:debug("message body size ~B exceeded maximum allowed ~B~n", [Size, MaxSize]),
 	Session ! {receive_data, {error, size_exceeded}};
 receive_data(Acc, Socket, RecvSize, Size, MaxSize, Session, Options) ->
 	case socket:recv(Socket, RecvSize, 1000) of
@@ -723,15 +723,15 @@ receive_data(Acc, Socket, RecvSize, Size, MaxSize, Session, Options) ->
 				FixedPacket ->
 					case binstr:strpos(FixedPacket, "\r\n.\r\n") of
 						0 ->
-							%io:format("received ~B bytes; size is now ~p~n", [RecvSize, Size + size(Packet)]),
-							%io:format("memory usage: ~p~n", [erlang:process_info(self(), memory)]),
+							lager:debug("received ~B bytes; size is now ~p~n", [RecvSize, Size + size(Packet)]),
+							lager:debug("memory usage: ~p~n", [erlang:process_info(self(), memory)]),
 							receive_data([FixedPacket | Acc], Socket, RecvSize, Size + byte_size(FixedPacket), MaxSize, Session, Options);
 						Index ->
 							String = binstr:substr(FixedPacket, 1, Index - 1),
 							Rest = binstr:substr(FixedPacket, Index+5),
-							%io:format("memory usage before flattening: ~p~n", [erlang:process_info(self(), memory)]),
+							lager:debug("memory usage before flattening: ~p~n", [erlang:process_info(self(), memory)]),
 							Result = list_to_binary(lists:reverse([String | Acc])),
-							%io:format("memory usage after flattening: ~p~n", [erlang:process_info(self(), memory)]),
+							lager:debug("memory usage after flattening: ~p~n", [erlang:process_info(self(), memory)]),
 							Session ! {receive_data, Result, Rest}
 					end
 			end;
@@ -743,15 +743,15 @@ receive_data(Acc, Socket, RecvSize, Size, MaxSize, Session, Options) ->
 				FixedPacket ->
 					case binstr:strpos(FixedPacket, "\r\n.\r\n") of
 						0 ->
-							%io:format("received ~B bytes; size is now ~p~n", [RecvSize, Size + size(Packet)]),
-							%io:format("memory usage: ~p~n", [erlang:process_info(self(), memory)]),
+							lager:debug("received ~B bytes; size is now ~p~n", [RecvSize, Size + size(Packet)]),
+							lager:debug("memory usage: ~p~n", [erlang:process_info(self(), memory)]),
 							receive_data([FixedPacket | Acc], Socket, RecvSize, Size + byte_size(FixedPacket), MaxSize, Session, Options);
 						Index ->
 							String = binstr:substr(FixedPacket, 1, Index - 1),
 							Rest = binstr:substr(FixedPacket, Index+5),
-							%io:format("memory usage before flattening: ~p~n", [erlang:process_info(self(), memory)]),
+							lager:debug("memory usage before flattening: ~p~n", [erlang:process_info(self(), memory)]),
 							Result = list_to_binary(lists:reverse([String | Acc])),
-							%io:format("memory usage after flattening: ~p~n", [erlang:process_info(self(), memory)]),
+							lager:debug("memory usage after flattening: ~p~n", [erlang:process_info(self(), memory)]),
 							Session ! {receive_data, Result, Rest}
 					end
 			end;
@@ -762,21 +762,21 @@ receive_data(Acc, Socket, RecvSize, Size, MaxSize, Session, Options) ->
 			case binstr:strpos(Packet, "\r\n.\r\n") of
 				0 ->
 					% uh-oh
-					%io:format("no data on socket, and no DATA terminator, retrying ~p~n", [Session]),
+					lager:debug("no data on socket, and no DATA terminator, retrying ~p~n", [Session]),
 					% eventually we'll either get data or a different error, just keep retrying
 					receive_data(Acc, Socket, 0, Size, MaxSize, Session, Options);
 				Index ->
 					String = binstr:substr(Packet, 1, Index - 1),
 					Rest = binstr:substr(Packet, Index+5),
-					%io:format("memory usage before flattening: ~p~n", [erlang:process_info(self(), memory)]),
+					lager:debug("memory usage before flattening: ~p~n", [erlang:process_info(self(), memory)]),
 					Result = list_to_binary(lists:reverse([String | Acc2])),
-					%io:format("memory usage after flattening: ~p~n", [erlang:process_info(self(), memory)]),
+					lager:debug("memory usage after flattening: ~p~n", [erlang:process_info(self(), memory)]),
 					Session ! {receive_data, Result, Rest}
 			end;
 		{error, timeout} ->
 			receive_data(Acc, Socket, 0, Size, MaxSize, Session, Options);
 		{error, Reason} ->
-			io:format("receive error: ~p~n", [Reason]),
+			lager:debug("receive error: ~p~n", [Reason]),
 			exit(receive_error)
 	end.
 

--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -77,7 +77,7 @@ decode(All, Options) when is_binary(All), is_list(Options) ->
 	decode(Headers, Body, Options).
 
 decode(OrigHeaders, Body, Options) ->
-	%io:format("headers: ~p~n", [Headers]),
+	lager:debug("headers: ~p~n", [OrigHeaders]),
 	Encoding = proplists:get_value(encoding, Options, none),
 	%FixedHeaders = fix_headers(Headers),
 	Headers = decode_headers(OrigHeaders, [], Encoding),
@@ -112,7 +112,7 @@ encode({Type, Subtype, Headers, ContentTypeParams, Parts}) ->
 		binstr:join(encode_component(Type, Subtype, FixedHeaders2, FixedParams, Parts),
 			"\r\n")]);
 encode(_) ->
-	io:format("Not a mime-decoded DATA~n"),
+	lager:debug("Not a mime-decoded DATA~n"),
 	erlang:error(non_mime).
 
 
@@ -178,7 +178,7 @@ decode_component(Headers, Body, MimeVsn, Options) when MimeVsn =:= <<"1.0">> ->
 				undefined ->
 					erlang:error(no_boundary);
 				Boundary ->
-					% io:format("this is a multipart email of type:  ~s and boundary ~s~n", [SubType, Boundary]),
+					% lager:debug("this is a multipart email of type:  ~s and boundary ~s~n", [SubType, Boundary]),
 					Parameters2 = [{<<"content-type-params">>, Parameters}, {<<"disposition">>, Disposition}, {<<"disposition-params">>, DispositionParams}],
 					{<<"multipart">>, SubType, Headers, Parameters2, split_body_by_boundary(Body, list_to_binary(["--", Boundary]), MimeVsn, Options)}
 			end;
@@ -187,7 +187,7 @@ decode_component(Headers, Body, MimeVsn, Options) when MimeVsn =:= <<"1.0">> ->
 			Parameters2 = [{<<"content-type-params">>, Parameters}, {<<"disposition">>, Disposition}, {<<"disposition-params">>, DispositionParams}],
 			{<<"message">>, <<"rfc822">>, Headers, Parameters2, decode(NewHeaders, NewBody, Options)};
 		{Type, SubType, Parameters} ->
-			%io:format("body is ~s/~s~n", [Type, SubType]),
+			lager:debug("body is ~s/~s~n", [Type, SubType]),
 			Parameters2 = [{<<"content-type-params">>, Parameters}, {<<"disposition">>, Disposition}, {<<"disposition-params">>, DispositionParams}],
 			{Type, SubType, Headers, Parameters2, decode_body(get_header_value(<<"Content-Transfer-Encoding">>, Headers), Body, proplists:get_value(<<"charset">>, Parameters), proplists:get_value(encoding, Options, none))};
 		undefined -> % defaults
@@ -202,7 +202,7 @@ decode_component(_Headers, _Body, Other, _Options) ->
 -spec(get_header_value/3 :: (Needle :: binary(), Headers :: [{binary(), binary()}], Default :: any()) -> binary() | any()).
 %% @doc Do a case-insensitive header lookup to return that header's value, or the specified default.
 get_header_value(Needle, Headers, Default) ->
-	%io:format("Headers: ~p~n", [Headers]),
+	lager:debug("Headers: ~p~n", [Headers]),
 	F =
 	fun({Header, _Value}) ->
 			binstr:to_lower(Header) =:= binstr:to_lower(Needle)
@@ -345,7 +345,7 @@ parse_headers(Body, <<H, T/binary>>, Headers) when H =:= $\s; H =:= $\t ->
 	% folded headers
 	[{FieldName, OldFieldValue} | OtherHeaders] = Headers,
 	FieldValue = list_to_binary([OldFieldValue, T]),
-	%io:format("~p = ~p~n", [FieldName, FieldValue]),
+	lager:debug("~p = ~p~n", [FieldName, FieldValue]),
 	case binstr:strpos(Body, "\r\n") of
 		0 ->
 			{lists:reverse([{FieldName, FieldValue} | OtherHeaders]), Body};
@@ -355,7 +355,7 @@ parse_headers(Body, <<H, T/binary>>, Headers) when H =:= $\s; H =:= $\t ->
 			parse_headers(binstr:substr(Body, Index2 + 2), binstr:substr(Body, 1, Index2 - 1), [{FieldName, FieldValue} | OtherHeaders])
 	end;
 parse_headers(Body, Line, Headers) ->
-	%io:format("line: ~p, nextpart ~p~n", [Line, binstr:substr(Body, 1, 10)]),
+	lager:debug("line: ~p, nextpart ~p~n", [Line, binstr:substr(Body, 1, 10)]),
 	case binstr:strchr(Line, $:) of
 		0 ->
 			{lists:reverse(Headers), list_to_binary([Line, "\r\n", Body])};
@@ -437,7 +437,7 @@ decode_quoted_printable(Line, Rest, Acc) ->
 		0 ->
 			decode_quoted_printable(Rest, <<>>, [decode_quoted_printable_line(Line, []) | Acc]);
 		Index ->
-			%io:format("next line ~p~nnext rest ~p~n", [binstr:substr(Rest, 1, Index +1), binstr:substr(Rest, Index + 2)]),
+			lager:debug("next line ~p~nnext rest ~p~n", [binstr:substr(Rest, 1, Index +1), binstr:substr(Rest, Index + 2)]),
 			decode_quoted_printable(binstr:substr(Rest, 1, Index +1), binstr:substr(Rest, Index + 2),
 				[decode_quoted_printable_line(Line, []) | Acc])
 	end.
@@ -728,7 +728,7 @@ encode_component_part(Part) ->
 					PartData
 			 );
 		_ ->
-			io:format("encode_component_part couldn't match Part to: ~p~n", [Part]),
+			lager:debug("encode_component_part couldn't match Part to: ~p~n", [Part]),
 			[]
 	end.
 


### PR DESCRIPTION
Using lager allows to easily switch out the logging level in the
application which uses gen_smtp as well as providing a much richer set
of debugging tools.
