### PR TITLE
Add client Sock Options configuration "sockopts"

### DIFF
--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -502,7 +502,7 @@ connect(Host, Options) ->
 		undefined -> [];
 		Other -> Other
 	end,
-	SockOpts = [binary, {packet, line}, {keepalive, true}, {active, false}] ++ AddSockOpts,
+    SockOpts = [binary, {packet, line}, {keepalive, true}, {active, false} | AddSockOpts],
 	Proto = case proplists:get_value(ssl, Options) of
 		true ->
 			ssl;


### PR DESCRIPTION
Hello,
With the `gen_smtp_client`, you cannot currently customize the interface used to connect to the server. This use case is very important with SMTP, since the ip used to connect to the server will be used by SPF for instance.

This pull request allows you to customize socket configuration with the `sockopts` option, allowing you to customize the socket parameters, for instance in the previously example : 

``` erlang
gen_smtp_client:send( {"whatever@example.com", ["andrew@hijacked.us"], SignedMailBody}, 
                                     [{relay,"xxxx"}, {sockopts,[{ifaddr,TheIpSourceYouWant}]}]).
```
