### PR TITLE
chore(Compiler Warnings): Use ssl:handshake instead of ssl:accept for…

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,8 @@
   debug_info,
   warn_unused_vars,
   warn_unused_import,
-  warn_exported_vars]}.
+  warn_exported_vars,
+  {platform_define, "(1[89]|20)", deprecated_ssl_accept}]}.
 
 {xref_checks,
  [undefined_function_calls,


### PR DESCRIPTION
… OTP versions >= 21

@arjan I'm not 100% if this syntax is correct or if it can be simplified, I'm relying on syntax highlighting from my editor and other examples from the repo. I will be happy to fix if anything looks wrong.  