### PR TITLE
Require otp18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: erlang
 notifications:
   email: you@example.org
 otp_release:
-  - 18.0
-  - 17.4
-  - R16B
+  - 22.0
+  - 21.3
+  - 20.3
+  - 19.3
+  - 18.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ otp_release:
   - 20.3
   - 19.3
   - 18.3
+script:
+  - make test
+  #- make xref
+  - make dialyze

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ dialyze:
 	./rebar3 as dialyzer dialyzer
 
 xref:
-	./rebar3 xref
+	./rebar3 as test xref
 
 .PHONY: compile clean test dialyze

--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,14 @@
            warn_unused_import,
            warn_exported_vars]}.
 
+{xref_checks,
+ [undefined_function_calls,
+  undefined_functions,
+  locals_not_used,
+  %% exports_not_used,
+  deprecated_function_calls,
+  deprecated_functions
+  ]}.
 
 {profiles, 
  [

--- a/rebar.config
+++ b/rebar.config
@@ -1,12 +1,11 @@
 %% -*- mode: erlang; -*-
-{require_min_otp_vsn, "R16"}.
+{require_min_otp_vsn, "18"}.
 
 {erl_opts, [fail_on_warning,
            debug_info,
            warn_unused_vars,
            warn_unused_import,
-           warn_exported_vars,
-           {platform_define, "^((1[89])|2)", deprecated_now}]}.
+           warn_exported_vars]}.
 
 
 {profiles, 

--- a/src/smtp_server_example.erl
+++ b/src/smtp_server_example.erl
@@ -220,13 +220,8 @@ terminate(Reason, State) ->
 
 %%% Internal Functions %%%
 
--ifdef(deprecated_now).
 unique_id() ->
     erlang:unique_integer().
--else.
-unique_id() ->
-    erlang:now().
--endif.
 
 -spec relay(binary(), [binary()], binary()) -> ok.
 relay(_, [], _) ->

--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -112,13 +112,8 @@ generate_message_boundary() ->
 	FQDN = guess_FQDN(),
     ["_=", [io_lib:format("~2.36.0b", [X]) || <<X>> <= erlang:md5(term_to_binary([unique_id(), FQDN]))], "=_"].
 
--ifdef(deprecated_now).
 unique_id() ->
     {erlang:system_time(), erlang:unique_integer()}.
--else.
-unique_id() ->
-    erlang:now().
--endif.
 
 -define(is_whitespace(Ch), (Ch =< 32)).
 


### PR DESCRIPTION
This one just updates travis.yml to more up-to-date erlang versions + adds dialyzer; xref now disabled because of some warnings that will be fixed by #172 and #173. Also some pre-erlang 18 workarounds removed.
I enabled travis for my fork repository, all builds are green https://travis-ci.org/seriyps/gen_smtp/builds/541978093