### PR TITLE
Fix typespec inet:socket_address() doesn't exist on OTP18

### DIFF
--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -72,7 +72,7 @@
                     {sockopts, [gen_tcp:connect_option()]} |
                     {port, inet:port_number()} |
                     {timeout, timeout()} |
-                    {relay, inet:socket_address() | inet:hostname()} |
+                    {relay, inet:ip_address() | inet:hostname()} |
                     {no_mx_lookups, boolean()} |
                     {auth, always | never | if_available} |
                     {hostname, string()} |


### PR DESCRIPTION
Should fix travis build - dialyzer on OTP-18 https://travis-ci.org/gen-smtp/gen_smtp/jobs/556946096#L591