### PR TITLE
Fallback to FQDN 'localhost' on failure to determine the FQDN of the current machine.

### DIFF
--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -62,7 +62,7 @@ guess_FQDN() ->
 
 guess_FQDN_1(_Hostname, {ok, #hostent{ h_name = FQDN }}) ->
 	FQDN;
-guess_FQDN_1(Hostname, {error, Error}) ->
+guess_FQDN_1(Hostname, {error, nxdomain = Error}) ->
     error_logger:info_msg("~p could not get FQDN for ~p (error ~p), using \"localhost\" instead.",
                           [?MODULE, Error, Hostname]),
     "localhost".

--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -30,6 +30,8 @@
          combine_rfc822_addresses/1,
          generate_message_boundary/0]).
 
+-include_lib("kernel/include/inet.hrl").
+
 %% @doc returns a sorted list of mx servers for `Domain', lowest distance first
 mxlookup(Domain) ->
 	case whereis(inet_db) of
@@ -52,12 +54,17 @@ mxlookup(Domain) ->
 			lists:sort(fun({Pref, _Name}, {Pref2, _Name2}) -> Pref =< Pref2 end, Result)
 	end.
 
-%% @doc guess the current host's fully qualified domain name
+%% @doc guess the current host's fully qualified domain name, on error return "localhost"
+-spec guess_FQDN() -> string().
 guess_FQDN() ->
 	{ok, Hostname} = inet:gethostname(),
-	{ok, Hostent} = inet:gethostbyname(Hostname),
-	{hostent, FQDN, _Aliases, inet, _, _Addresses} = Hostent,
-	FQDN.
+    guess_FQDN_1(Hostname, inet:gethostbyname(Hostname)).
+
+guess_FQDN_1(_Hostname, {ok, #hostent{ h_name = FQDN }}) ->
+	FQDN;
+guess_FQDN_1(Hostname, {error, nxdomain}) ->
+    error_logger:info_msg("~p could not get FQDN for ~p, using \"localhost\" instead.", [?MODULE, Hostname]),
+    "localhost".
 
 %% @doc Compute the CRAM digest of `Key' and `Data'
 -spec compute_cram_digest(Key :: binary(), Data :: binary()) -> binary().

--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -62,8 +62,9 @@ guess_FQDN() ->
 
 guess_FQDN_1(_Hostname, {ok, #hostent{ h_name = FQDN }}) ->
 	FQDN;
-guess_FQDN_1(Hostname, {error, nxdomain}) ->
-    error_logger:info_msg("~p could not get FQDN for ~p, using \"localhost\" instead.", [?MODULE, Hostname]),
+guess_FQDN_1(Hostname, {error, Error}) ->
+    error_logger:info_msg("~p could not get FQDN for ~p (error ~p), using \"localhost\" instead.",
+                          [?MODULE, Error, Hostname]),
     "localhost".
 
 %% @doc Compute the CRAM digest of `Key' and `Data'


### PR DESCRIPTION
Fixes #152

Errors deriving the FQDN are logged.
Crash if the error is something else than `nxdomain`, as that might hide other problems.