### PR TITLE
Soften some race conditions in tests. 

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -991,7 +991,8 @@ smtp_session_test_() ->
 				{CSock, Pid}
 		end,
 		fun({CSock, _Pid}) ->
-				smtp_socket:close(CSock)
+				smtp_socket:close(CSock),
+				timer:sleep(10)
 		end,
 		[fun({CSock, _Pid}) ->
 					{"A new connection should get a banner",
@@ -1296,7 +1297,8 @@ smtp_session_auth_test_() ->
 				{CSock, Pid}
 		end,
 		fun({CSock, _Pid}) ->
-				smtp_socket:close(CSock)
+				smtp_socket:close(CSock),
+				timer:sleep(10)
 		end,
 		[fun({CSock, _Pid}) ->
 					{"EHLO response includes AUTH",
@@ -1803,7 +1805,8 @@ smtp_session_tls_test_() ->
 				{CSock, Pid}
 		end,
 		fun({CSock, _Pid}) ->
-				smtp_socket:close(CSock)
+				smtp_socket:close(CSock),
+				timer:sleep(10)
 		end,
 		[fun({CSock, _Pid}) ->
 					{"EHLO response includes STARTTLS",

--- a/src/smtp_socket.erl
+++ b/src/smtp_socket.erl
@@ -359,15 +359,18 @@ connect_test_() ->
 		fun() ->
 			Self = self(),
 			Port = ?TEST_PORT + 1,
+			Ref = make_ref(),
 			spawn(fun() ->
 						{ok, ListenSocket} = listen(tcp, Port),
 						?assert(is_port(ListenSocket)),
+						Self ! {Ref, listen},
 						{ok, ServerSocket} = accept(ListenSocket),
 						controlling_process(ServerSocket, Self),
-						Self ! ListenSocket
+						Self ! {Ref, ListenSocket}
 				end),
+			receive {Ref, listen} -> ok end,
 			{ok, ClientSocket} = connect(tcp, "localhost", Port),
-			receive ListenSocket when is_port(ListenSocket) -> ok end,
+			receive {Ref, ListenSocket} when is_port(ListenSocket) -> ok end,
 			?assert(is_port(ClientSocket)),
 			close(ListenSocket)
 		end
@@ -376,16 +379,19 @@ connect_test_() ->
 		fun() ->
 			Self = self(),
 			Port = ?TEST_PORT + 2,
+			Ref = make_ref(),
 	        gen_smtp_application:ensure_all_started(gen_smtp),
 			spawn(fun() ->
 						{ok, ListenSocket} = listen(ssl, Port, [{keyfile, "test/fixtures/server.key"}, {certfile, "test/fixtures/server.crt"}]),
 						?assertMatch([sslsocket|_], tuple_to_list(ListenSocket)),
+						Self ! {Ref, listen},
 						{ok, ServerSocket} = accept(ListenSocket),
 						controlling_process(ServerSocket, Self),
-						Self ! ListenSocket
+						Self ! {Ref, ListenSocket}
 				end),
+			receive {Ref, listen} -> ok end,
 			{ok, ClientSocket} = connect(ssl, "localhost", Port,  []),
-			receive {sslsocket,_,_} = ListenSocket -> ok end,
+			receive {Ref, {sslsocket,_,_} = ListenSocket} -> ok end,
 			?assertMatch([sslsocket|_], tuple_to_list(ClientSocket)),
 			close(ListenSocket)
 		end


### PR DESCRIPTION
Fixes #182

This softens a race condition when opening/closing sockets during `gen_smtp_server_session` tests.

Also removes a race condition in `smtp_socket` tests.