### PR TITLE
smtp_socket should support some out of date ciphers in OTP 21 and above

### DIFF
--- a/src/smtp_socket.erl
+++ b/src/smtp_socket.erl
@@ -47,6 +47,7 @@
                               {depth, 0},
                               {packet, line},
                               {ip, {0,0,0,0}},
+							  {ciphers, ssl:cipher_suites(all, tlsv1)},
                               {versions, ['tlsv1', 'tlsv1.1', 'tlsv1.2']},
                               {port, 0}]).
 

--- a/src/smtp_socket.erl
+++ b/src/smtp_socket.erl
@@ -47,7 +47,7 @@
                               {depth, 0},
                               {packet, line},
                               {ip, {0,0,0,0}},
-							  {ciphers, ssl:cipher_suites(all, tlsv1)},
+                              {ciphers, ssl:cipher_suites(default,'tlsv1.2')},
                               {versions, ['tlsv1', 'tlsv1.1', 'tlsv1.2']},
                               {port, 0}]).
 


### PR DESCRIPTION
Dear author

I have met a problem when I deal with some old system.
The ciphers of ssl only support old algorithms, but the OTP 21 and above won't use them in default `ssl:connect`.
When I pass these algorithms into gen_smtp, I found the library drops them.
So I add default option in SSL_CONNECT_OPTIONS to support it.

Thanks & Regards
