### PR TITLE
Don't overwrite ranch socket_opts (ranch 1.6+)

### DIFF
--- a/src/gen_smtp_server.erl
+++ b/src/gen_smtp_server.erl
@@ -98,6 +98,7 @@ convert_options(CallbackModule, Options) ->
 		case RanchVer of
 			gte16 ->
 				RanchOpts = proplists:get_value(ranch_opts, Options, #{}),
+				SocketOpts = maps:get(socket_opts, RanchOpts, []),
 				NumAcceptors_ = maps:get(num_acceptors, RanchOpts, 10),
 				{NumAcceptors_,
 				 RanchOpts#{
@@ -106,7 +107,8 @@ convert_options(CallbackModule, Options) ->
 						{ip, Address},
 						{keepalive, true},
 						%% binary, {active, false}, {reuseaddr, true} - ranch defaults
-						Family]}};
+						Family
+					   | SocketOpts]}};
 			lt16 ->
 				RanchOpts = proplists:get_value(ranch_opts, Options, []),
 				NumAcceptors_ = proplists:get_value(num_acceptors, RanchOpts, 10),


### PR DESCRIPTION
For ranch 1.6+ server if we start smtp server as, eg

```erlang
gen_smtp_server:start(Name, Mod, [<..>, {ranch_opts, #{socket_opts => [{ipv6_v6only, true}]}}]).
```

this `socket_opts` parameter in `ranch_opts` will be overwritten, which is not the case for ranch <1.6, and there is no workaround for this.
My usecase was to provide `{ipv6_v6only, true}` option in order to be able to start 2 listeners on all IPs both ipv4 and ipv6 and same port (`0.0.0.0:25` and `[::]:25`).
With this patch it's now possible:

```erlang
> gen_smtp_server:start(
    inet6,
    smtp_server_example,
    [{address, {0,0,0,0,0,0,0,0}},
     {port, 2525},
     {family, inet6},
     {domain, "localhost"},
     {ranch_opts, #{socket_opts => [{ipv6_v6only, true}]}}]).    
{ok,<0.295.0>}                                                                                       
> gen_smtp_server:start(
    inet,
    smtp_server_example,
    [{address, {0,0,0,0}},
     {port, 2525},
     {family, inet},
     {domain, "localhost"},
     {ranch_opts, #{socket_opts => []}}]).                             
{ok,<0.309.0>}                                 
> ranch:info().                           
[{inet,[{pid,<0.309.0>},                        
        {status,running},                                                                            
        {ip,{0,0,0,0}},                                                                              
        {port,2525},                                                                                 
        {max_connections,1024},                                                                                                                                                                            
        {active_connections,0},                                                                      
        {all_connections,0},                                                                         
        {transport,ranch_tcp},                                                                       
        {transport_options,#{socket_opts =>
                                 [{port,2525},{ip,{0,0,0,0}},{keepalive,true},inet]}},   
        {protocol,gen_smtp_server_session},                                                          
        {protocol_options,{smtp_server_example,gte16,
                                               [{hostname,"localhost"}]}}]},
 {inet6,[{pid,<0.295.0>},                                                                                                                                                                                  
         {status,running},                                                                           
         {ip,{0,0,0,0,0,0,0,0}},               
         {port,2525},                                                                                                                                                                                      
         {max_connections,1024},
         {active_connections,0},   
         {all_connections,0},          
         {transport,ranch_tcp},       
         {transport_options,#{socket_opts =>                                                         
                                  [{port,2525},
                                   {ip,{0,0,0,0,0,0,0,0}},           
                                   {keepalive,true},
                                   inet6,                                                            
                                   {ipv6_v6only,true}]}},                       
         {protocol,gen_smtp_server_session},
         {protocol_options,{smtp_server_example,gte16,
                                                [{hostname,"localhost"}]}}]}]
```