### PR TITLE
Fix edocs build. Add edoc build to CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.beam
 erl_crash.dump
 coverage/*
+doc/
 .DS_Store
 build
 *.xcodeproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ matrix:
 script:
   - make test
   #- make xref
+  - '[ "$TRAVIS_OTP_RELEASE" \< "21.0" ] || make docs'  # disable edoc on older OTP
   - make dialyze

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,7 @@ dialyze:
 xref:
 	./rebar3 as test xref
 
+docs:
+	./rebar3 edoc
+
 .PHONY: compile clean test dialyze

--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -76,9 +76,9 @@
 		{default_mime_version, ?DEFAULT_MIME_VERSION} % default mime version
 	]).
 
--type mime_type() :: binary().                  % <<"text">>
--type mime_subtype() :: binary().               % <<"plain">>
--type headers() :: [{binary(), binary()}].      % [{<<"Content-Type">>, <<"text/plain">>}]
+-type mime_type() :: binary().                  % `<<"text">>'
+-type mime_subtype() :: binary().               % `<<"plain">>'
+-type headers() :: [{binary(), binary()}].      % `[{<<"Content-Type">>, <<"text/plain">>}]'
 -type parameters() ::
         #{transfer_encoding => binary(),
           %% [{<<"charset">>, <<"utf-8">>} | {<<"boundary">>, binary()} | {<<"name">>, binary()} etc...]


### PR DESCRIPTION
I discovered that `gen_smtp` has quite decent "edocs". Just has some minor issues which crashed the build.

So, fixed those issues and added edoc build to Travis to make sure it will continue to work.

![image](https://user-images.githubusercontent.com/422014/94629184-53562e80-02c2-11eb-8559-bb27a3cfb606.png)
