### PR TITLE
Add test coverage to CI; fail if coverage falls below the limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ matrix:
       dist: trusty
 script:
   - make test
+  - make cover
   #- make xref
   - make dialyze

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+MINIMAL_COVERAGE = 75
+
 compile:
 	@./rebar3 compile
 
@@ -6,7 +8,10 @@ clean:
 
 test:
 	ERL_AFLAGS="-s ssl" 
-	./rebar3 eunit
+	./rebar3 eunit -c
+
+cover:
+	./rebar3 cover --verbose --min_coverage $(MINIMAL_COVERAGE)
 
 dialyze:
 	./rebar3 as dialyzer dialyzer


### PR DESCRIPTION
Current test coverage is about 82%. I set a threshold a bit lower to have some degree of freedom.

It looks like this in travis logs:

```
===> Performing cover analysis...
  |---------------------------|------------|
  |                   module  |  coverage  |
  |---------------------------|------------|
  |          gen_smtp_client  |       80%  |
  |      smtp_server_example  |       53%  |
  |          gen_smtp_server  |       65%  |
  |                smtp_util  |       71%  |
  |                 mimemail  |       95%  |
  |  gen_smtp_server_session  |       78%  |
  |              smtp_socket  |       92%  |
  |     gen_smtp_application  |       83%  |
  |                   binstr  |       61%  |
  |        smtp_rfc822_parse  |       66%  |
  |---------------------------|------------|
  |                    total  |       82%  |
  |---------------------------|------------|

  coverage calculated from:
    /home/travis/build/gen-smtp/gen_smtp/_build/test/cover/eunit.coverdata
  cover summary written to: /home/travis/build/gen-smtp/gen_smtp/_build/test/cover/index.html
The command "make cover" exited with 0.
```