### PR TITLE
Fix/rebar dependency loosen

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,8 +23,8 @@
   {smtp_rfc822_parse, return_error, 2}
  ]}.
 
-{deps, [{ranch, "1.6.2"},
-        {hut, "1.3.0"}]}.
+{deps, [{ranch, "~> 1.6"},
+        {hut, "~> 1.3"}]}.
 
 {profiles,
  [
@@ -32,7 +32,7 @@
    [
     {deps,
      [
-      {eiconv, "1.0.0"}
+      {eiconv, "~> 1.0"}
      ]
     },
     {dialyzer,
@@ -51,16 +51,16 @@
      ]}
    ]},
   {ranch13,
-   [{deps, [{ranch, "1.3.2"}]}]},
+   [{deps, [{ranch, "~> 1.3"}]}]},
   {ranch20,
-   [{deps, [{ranch, "2.0.0"}]}]},
-  {test, 
+   [{deps, [{ranch, "~> 2.0"}]}]},
+  {test,
    [
     {cover_enabled, true},
     {cover_print_enabled, true},
     {deps,
      [
-      {eiconv, "1.0.0"}
+      {eiconv, "~> 1.0"}
      ]}
    ]}
  ]}.


### PR DESCRIPTION
Compiling `swoosh` upstream yields an error:

```
Failed to use "ranch" because
  gen_smtp (versions 1.0.0 and 1.0.1) requires 1.6.2
  mix.lock specifies 1.7.1

** (Mix) Hex dependency resolution failed, change the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}
```

This branch uses looser version specifiers in `rebar.config` for our dependencies.