### PR TITLE
Drop support for OTP-18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
     - otp_release: 21.3
     - otp_release: 20.3
     - otp_release: 19.3
-    - otp_release: 18.3
-      dist: trusty
 script:
   - make test
   - make cover

--- a/rebar.config
+++ b/rebar.config
@@ -1,13 +1,12 @@
 %% -*- mode: erlang; -*-
-{require_min_otp_vsn, "18"}.
+{require_min_otp_vsn, "19"}.
 
 {erl_opts,
  [fail_on_warning,
   debug_info,
   warn_unused_vars,
   warn_unused_import,
-  warn_exported_vars,
-  {platform_define, "18", 'OTP_18'}]}.
+  warn_exported_vars]}.
 
 {xref_checks,
  [undefined_function_calls,

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -78,7 +78,6 @@
 	}
 ).
 
-%% OTP-18: ssl:ssloption() (not exported)
 %% OTP-19: ssl:ssl_option()
 %% OTP-20: ssl:ssl_option()
 %% OTP-21: ssl:tls_server_option()
@@ -87,11 +86,7 @@
 -ifdef(OTP_RELEASE).
 -type tls_opt() :: ssl:tls_server_option().
 -else.
- -ifdef(OTP_18).
- -type tls_opt() :: tuple() | atom().
- -else.
- -type tls_opt() :: ssl:ssl_option().
- -endif.
+-type tls_opt() :: ssl:ssl_option().
 -endif.
 
 -type options() :: [  {callbackoptions, any()}
@@ -2442,14 +2437,9 @@ strict_sni(Hosts) ->
 	 end
 	}.
 
--ifdef(OTP_18).
-verify_cert_hostname(_, _) ->
-	noop.
--else.
 verify_cert_hostname(BinCert, Host) ->
 	DecCert = public_key:pkix_decode_cert(BinCert, otp),
 	?assert(public_key:pkix_verify_hostname(DecCert, [{dns_id, Host}])).
--endif.
 
 stray_newline_test_() ->
 	[


### PR DESCRIPTION
OTP-18 apparently is not that much of effort to still support, but I think it just doesn't make sense. OTP-18.3 was released 14 Mar 2016 and is not supported by OTP team anymore.

If someone still needs it, hey can stick to gen_smtp 1.0