### PR TITLE
Smtp server - better error handling

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -976,8 +976,13 @@ send(#state{transport = Transport, socket = Sock}, Data) ->
     %% TODO: handle send errors
     Transport:send(Sock, Data).
 
-setopts(#state{transport = Transport, socket = Sock}, Opts) ->
-    ok = Transport:setopts(Sock, Opts).
+setopts(#state{transport = Transport, socket = Sock} = St, Opts) ->
+    case Transport:setopts(Sock, Opts) of
+		ok -> ok;
+		{error, Err} ->
+			St1 = handle_error(setopts, Err, St),
+			throw({stop, {setopts_error, Err}, St1})
+	end.
 
 hostname(Opts) ->
     proplists:get_value(hostname, Opts, smtp_util:guess_FQDN()).

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -831,7 +831,7 @@ try_auth(AuthType, Username, Credential, #state{module = Module, envelope = Enve
 					{ok, NewState}
 				end;
 		false ->
-			error_logger:error_msg("Please define handle_AUTH/4 in your server module or remove AUTH from your module extensions~n"),
+			?log(warning, "Please define handle_AUTH/4 in your server module or remove AUTH from your module extensions~n"),
 			send(State, "535 authentication failed (#5.7.1)\r\n"),
 			{ok, NewState}
 	end.
@@ -908,7 +908,7 @@ receive_data(Acc, Transport, Socket, RecvSize, Size, MaxSize, Session, Options) 
 		{error, timeout} ->
 			receive_data(Acc, Transport, Socket, 0, Size, MaxSize, Session, Options);
 		{error, Reason} ->
-			error_logger:error_msg("SMTP receive error: ~p~n", [Reason]),
+			?log(warning, "SMTP receive error: ~p", [Reason]),
 			exit(receive_error)
 	end.
 


### PR DESCRIPTION
4 independent commits, might be easier to review one by one.

This way we let callback module to decide how to handle such errors. All 3 are actually non-recoverable, as far as I understand, but we didn't crash on `send` historically.

We will stop the session process anyway (callback module can avoid crash logs by returning `{stop, normal, State}` from the `handle_error` function). For `send` error we are changing previous behaviour (used to ignore, now are going to stop).