### PR TITLE
Updated README section about send option values for auth

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,12 +78,12 @@ The `send` method variants `send/2, send/3, send_blocking/2` take an `Options` a
   * **relay** the smtp relay, e.g. `"smtp.gmail.com"`
   * **username** the username of the smtp relay e.g. `"me@gmail.com"`
   * **password** the password of the smtp relay e.g. `"mypassword"`
-  * **auth** whether the smtp server needs authentication, valid values are `if_available` and `always`, Defaults to `if_available`. If your smtp relay requires authentication set it to `always`
-  * **ssl** whether to connect on 465 in ssl mode, Defaults to `false`
-  * **tls** valid values are `always`, `never`, `if_available`. Most modern smtp relays use tls, so set this to `always`, Defaults to `if_available`
-  * **tls_options** used in `ssl:connect`, More info at http://erlang.org/doc/man/ssl.html , Defaults to `[{versions , ['tlsv1', 'tlsv1.1', 'tlsv1.2']}]`, This is merged with options listed at: https://github.com/gen-smtp/gen_smtp/blob/master/src/smtp_socket.erl#L46 . Any options not present in this list will be ignored.
-  * **hostname** the hostname to be used by the smtp relay, Defaults to: `smtp_util:guess_FQDN()`. The hostname on your computer might not be correct, so set this to a valid value.
-  * **retries** how many retries per smtp host on temporary failure, Defaults to 1, which means it will retry once if there is a failure.
+  * **auth** whether the smtp server needs authentication. Valid values are `if_available`, `always`, and `never`. Defaults to `if_available`. If your smtp relay requires authentication set it to `always`
+  * **ssl** whether to connect on 465 in ssl mode. Defaults to `false`
+  * **tls** valid values are `always`, `never`, `if_available`. Most modern smtp relays use tls, so set this to `always`. Defaults to `if_available`
+  * **tls_options** used in `ssl:connect`, More info at http://erlang.org/doc/man/ssl.html . Defaults to `[{versions , ['tlsv1', 'tlsv1.1', 'tlsv1.2']}]`. This is merged with options listed at: https://github.com/gen-smtp/gen_smtp/blob/master/src/smtp_socket.erl#L46 . Any options not present in this list will be ignored.
+  * **hostname** the hostname to be used by the smtp relay. Defaults to: `smtp_util:guess_FQDN()`. The hostname on your computer might not be correct, so set this to a valid value.
+  * **retries** how many retries per smtp host on temporary failure. Defaults to 1, which means it will retry once if there is a failure.
 
 
 ### DKIM signing of outgoing emails


### PR DESCRIPTION
Added 'never' to list of valid values for send option auth.

Also changed few commas to dots.

Fixes #231 