### PR TITLE
Be explicit in our intentions (OTP 24 readiness)

### DIFF
--- a/src/gen_smtp_application.erl
+++ b/src/gen_smtp_application.erl
@@ -9,7 +9,7 @@ ensure_all_started(App) ->
 
 -spec start_ok(atom(), ok | {error, term()}) -> ok | {error, {term(), atom()}}.
 start_ok(_App, ok) -> ok;
-start_ok(_App, {error, {already_started, _App}}) -> ok;
+start_ok(App, {error, {already_started, App}}) -> ok;
 start_ok(App, {error, {not_started, Dep}}) ->
     ok = ensure_all_started(Dep),
     ensure_all_started(App);

--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -1513,7 +1513,7 @@ parse_example_mails_test_() ->
 				?assertMatch({<<"text">>, <<"plain">>, _, _, _}, Toptext),
 				?assertEqual(<<"This is rich text.\r\n\r\nThe list is html.\r\n\r\nAttchments:\r\nan email containing an attachment of an email.\r\nan email of only plain text.\r\nan image\r\nan rtf file.\r\n">>, element(5, Toptext)),
 				?assertEqual(9, length(element(5, Topmultipart))),
-				[Html, Messagewithin, _Brhtml, _Message, _Brhtml, Image, _Brhtml, Rtf, _Brhtml] = element(5, Topmultipart),
+				[Html, Messagewithin, Brhtml, _Message, Brhtml, Image, Brhtml, Rtf, Brhtml] = element(5, Topmultipart),
 				?assertMatch({<<"text">>, <<"html">>, _, _, _}, Html),
 				?assertEqual(<<"<html><body style=\"word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-line-break: after-white-space; \"><b>This</b> is <i>rich</i> text.<div><br></div><div>The list is html.</div><div><br></div><div>Attchments:</div><div><ul class=\"MailOutline\"><li>an email containing an attachment of an email.</li><li>an email of only plain text.</li><li>an image</li><li>an rtf file.</li></ul></div><div></div></body></html>">>, element(5, Html)),
 


### PR DESCRIPTION
This pull request fixes two minor warnings that OTP 24 will present after https://github.com/erlang/otp/pull/2995.