### PR TITLE
Fix session count in server session initialization

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -174,7 +174,7 @@ init([Ref, Transport, Socket, Module, Options]) ->
 	end,
 	case PeerName =/= error
 		andalso Module:init(hostname(Options),
-							proplists:get_value(sessioncount, Options, 0), %FIXME
+							size(gen_smtp_server:sessions(Ref)),
 							PeerName,
 							proplists:get_value(callbackoptions, Options, []))
 	of


### PR DESCRIPTION
gen_smtp_server_session's init/1 callback passes the current session count to the callback module. This count should be pulled from gen_smtp_server's sessions/1 function, instead of the callback options.