### PR TITLE
use current session count in session init callback

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -174,7 +174,7 @@ init([Ref, Transport, Socket, Module, Options]) ->
 	end,
 	case PeerName =/= error
 		andalso Module:init(hostname(Options),
-							proplists:get_value(sessioncount, Options, 0), %FIXME
+							length(gen_smtp_server:sessions(Ref)),
 							PeerName,
 							proplists:get_value(callbackoptions, Options, []))
 	of


### PR DESCRIPTION
gen_smtp_server_session's init/4 callback relies on the current session count, which should come from gen_smtp_server's sessions/1 function. This commit makes that change.

Ignore the last PR I submitted, that used the size/1 function instead of length/1 (I'm a bit unfamiliar with Erlang since I primarily use Elixir)