### PR TITLE
Add LMTP as an option for the protocol implementation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -195,6 +195,12 @@ Session options are:
 * `{tls_options, [ssl:server_option()]}` - options to pass to `ssl:handshake/3` (OTP-21+) / `ssl:ssl_accept/3`
   when `STARTTLS` command is sent by the client. Only needed if `STARTTLS` extension
   is enabled
+* `{protocol, smtp | lmtp}` - when `lmtp` is passed, the control flow of the
+  [Local Mail Tranfer Protocol](https://tools.ietf.org/html/rfc2033) is applied.
+  LMTP is derived from SMTP with just a few variations and is used by standard
+  [Mail Transfer Agents (MTA)](https://en.wikipedia.org/wiki/Message_transfer_agent), like Postfix, Exim and OpenSMTPD to
+  send incoming email to local mail-handling applications that usually don't have a delivery queue.
+  The default value of this option is `smtp`.
 * `{callbackoptions, any()}` - value will be passed as 4th argument to callback module's `init/4`
 
 You can connect and test this using the `gen_smtp_client` via something like:

--- a/README.markdown
+++ b/README.markdown
@@ -213,6 +213,12 @@ gen_smtp_client:send(
 
 If you want to listen on IPv6, you can use the `{family, inet6}` and `{address, "::"}` options to enable listening on IPv6.
 
+Please notice that when using the LMTP protocol, the `handle_EHLO` callback will be used
+to handle the `LHLO` command as defined in [RFC2033](https://tools.ietf.org/html/rfc2033),
+due to their similarities. Although not used, the implementation of `handle_HELO` is still
+mandatory for the general `gen_smtp_server_session` behaviour (you can simply
+return a 500 error, e.g. `{error, "500 LMTP server, not SMTP"}`).
+
 ## Dependency on iconv
 
 gen_smtp relies on iconv for text encoding and decoding when parsing is activated.

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -235,7 +235,7 @@ report_recipient(error, Message, State) ->
 report_recipient(multiple, _Any, #state{variant = smtp} = State) ->
 	Msg = "SMTP should report a single delivery status for all the recipients",
 	throw({stop, {handle_DATA_error, Msg}, State});
-report_recipient(multiple, [], State) -> ok;
+report_recipient(multiple, [], _State) -> ok;
 report_recipient(multiple, [{ResponseType, Value} | Rest], State) ->
 	report_recipient(ResponseType, Value, State),
 	report_recipient(multiple, Rest, State).

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -175,14 +175,7 @@ ranch_init({Ref, Transport, {Callback, Opts}}) ->
 init([Ref, Transport, Socket, Module, Options]) ->
     Protocol = proplists:get_value(protocol, Options, smtp),
 	PeerName = case Transport:peername(Socket) of
-		{ok, {IPaddr, Port}} ->
-			case {Protocol, Port} of
-				{lmtp, 25} ->
-					?log(debug, "error: LMTP is different from SMTP, it MUST NOT be used on the TCP port 25."),
-					% Error defined in section 5 of https://tools.ietf.org/html/rfc2033
-					error;
-				_ -> IPaddr
-			end;
+		{ok, {IPaddr, _Port}} -> IPaddr;
 		{error, _} -> error
 	end,
 	case PeerName =/= error

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -218,7 +218,6 @@ handle_call(Request, _From, State) ->
 handle_cast(_Msg, State) ->
 	{noreply, State}.
 
-
 %% @hidden
 -spec handle_info(Message :: any(), State :: #state{}) -> {'noreply', #state{}} | {'stop', any(), #state{}}.
 handle_info({receive_data, {error, size_exceeded}}, #state{readmessage = true} = State) ->
@@ -999,6 +998,7 @@ setopts(#state{transport = Transport, socket = Sock} = St, Opts) ->
 hostname(Opts) ->
     proplists:get_value(hostname, Opts, smtp_util:guess_FQDN()).
 
+%% @hidden
 lhlo_if_lmtp(Protocol, Fallback) ->
 	case Protocol == lmtp of
 	    true -> "LHLO";

--- a/src/smtp_server_example.erl
+++ b/src/smtp_server_example.erl
@@ -150,7 +150,7 @@ handle_RCPT_extension(Extension, _State) ->
 queue_or_deliver(From, To, Data, Reference, State) ->
 	% At this point, if we return ok, we've accepted responsibility for the emaill
 	Length = byte_size(Data),
-	case proplists:get_value(variant, State#state.options, smtp) of
+	case proplists:get_value(protocol, State#state.options, smtp) of
 		smtp ->
 			?log(info, "message from ~s to ~p queued as ~s, body length ~p~n", [From, To, Reference, Length]),
 			% ... should actually handle the email,

--- a/src/smtp_server_example.erl
+++ b/src/smtp_server_example.erl
@@ -14,7 +14,8 @@
 
 -record(state,
 	{
-		options = [] :: list()
+		options = [] :: list(),
+		recipients = [] :: [string()]
 	}).
 
 -type(error_message() :: {'error', string(), #state{}}).
@@ -124,10 +125,10 @@ handle_MAIL_extension(Extension, _State) ->
 -spec handle_RCPT(To :: binary(), State :: #state{}) -> {'ok', #state{}} | {'error', string(), #state{}}.
 handle_RCPT(<<"nobody@example.com">>, State) ->
 	{error, "550 No such recipient", State};
-handle_RCPT(To, State) ->
+handle_RCPT(To, #state{recipients = Recipients} = State) ->
 	?log(info, "Mail to ~s~n", [To]),
-	% you can accept or reject RCPT TO addesses here, one per call
-	{ok, State}.
+	% you can accept or reject RCPT TO addresses here, one per call
+	{ok, State#state{recipients = [To | Recipients]}}.
 
 -spec handle_RCPT_extension(Extension :: binary(), State :: #state{}) -> {'ok', #state{}} | 'error'.
 handle_RCPT_extension(<<"X-SomeExtension">> = Extension, State) ->
@@ -138,20 +139,80 @@ handle_RCPT_extension(Extension, _State) ->
 	?log(warning, "Unknown RCPT TO extension ~s~n", [Extension]),
 	error.
 
--spec handle_DATA(From :: binary(), To :: [binary(),...], Data :: binary(), State :: #state{}) -> {'ok', string(), #state{}} | {'error', string(), #state{}}.
+%% @doc Helps `handle_DATA' to deal with the received email.
+%% This function is not directly required by the behaviour.
+-spec queue_or_deliver(From :: binary(),
+					   To :: [binary(),...],
+					   Data :: binary(),
+					   Reference :: string(),
+					   State :: #state{}
+					  ) -> {ok | error, string(), #state{}} |
+						   {multiple, [{ok | error, string()}], #state{}}.
+queue_or_deliver(From, To, Data, Reference, State) ->
+	% At this point, if we return ok, we've accepted responsibility for the emaill
+	Length = byte_size(Data),
+	Recipients = State#state.recipients,
+	Variant = proplists:get_value(variant, State#state.options, smtp),
+	case {Variant, Recipients} of
+		{smtp, _} ->
+			?log(info, "message from ~s to ~p queued as ~s, body length ~p~n", [From, To, Reference, Length]),
+			% ... should actually handle the email,
+			%     if `ok` is returned we are taking the responsibility of the delivery.
+			{ok, ["queued as ~s", Reference], State};
+		{lmtp, []} ->
+			?log(info, "message from ~s to ~p rejected: no successful recipients~n", [From, To]),
+			{error, "503 Error: No successful RCPT TO command"};
+		{lmtp, _} ->
+			?log(info, "message from ~s delivered to ~p, body length ~p~n", [From, Recipients, Length]),
+			Multiple = [{ok, ["delivered to ", Recipient]} || Recipient <- Recipients],
+			% ... should actually handle the email for each recipient for each `ok`
+			{multiple, Multiple, State}
+	end.
+
+%% @doc Handle the DATA verb from the client, which corresponds to the body of
+%% the message. After receiving the body, a SMTP server can put the email in
+%% a queue for later delivering while a LMTP server can handle the delivery
+%% directly (LMTP servers are supposed to be simpler and handle emails to
+%% local users directly without the need for a queue). Relaying the email to
+%% another server is also an option.
+%%
+%% When using the SMTP protocol, `handle_DATA' should return a single "aggregate" delivery status
+%% in the form of a `{ok, SuccessMsg, State}' tuple or `{error, ErrorMsg, State}'.
+%% At this point, if `ok' is returned, we have accepted the full responsibility
+%% of delivering the email.
+%%
+%% When using the LMTP protocol, `handle_DATA' should return a status for
+%% each accepted address in `handle_RCPT' in the form of a `{multiple, StatusList, State}' tuple
+%% where `StatusList' is a list of `{ok, SuccessMsg}' or `{error, ErrorMsg}' tuples
+%% (the statuses should be presented in the same order as the recipient addresses were accepted).
+%% For each `ok' in the `StatusList', we have accepted full responsibility for
+%% delivering the email to that specific recipient. When a single recipient is
+%% specified the returned value can also follow the SMTP format.
+%%
+%% `ErrorMsg' should always start with the SMTP error code, while `SuccessMsg'
+%% should not (the `250' code is automatically prepended).
+%%
+%% According to the SMTP specification the, responsibility of delivering an
+%% email must be taken seriously and the servers MUST NOT loose the message.
+-spec handle_DATA(From :: binary(),
+				  To :: [binary(),...],
+				  Data :: binary(),
+				  State :: #state{}
+				 ) -> {ok | error, string(), #state{}} |
+					  {multiple, [{ok | error, string()}], #state{}}.
 handle_DATA(_From, _To, <<>>, State) ->
 	{error, "552 Message too small", State};
 handle_DATA(From, To, Data, State) ->
 	% some kind of unique id
-    Reference = lists:flatten([io_lib:format("~2.16.0b", [X]) || <<X>> <= erlang:md5(term_to_binary(unique_id()))]),
 	% if RELAY is true, then relay email to email address, else send email data to console
 	case proplists:get_value(relay, State#state.options, false) of
 		true -> relay(From, To, Data);
 		false ->
-			?log(info, "message from ~s to ~p queued as ~s, body length ~p~n", [From, To, Reference, byte_size(Data)]),
+			Reference = lists:flatten([io_lib:format("~2.16.0b", [X]) || <<X>> <= erlang:md5(term_to_binary(unique_id()))]),
 			case proplists:get_value(parse, State#state.options, false) of
 				false -> ok;
 				true ->
+					% In this example we try to decode the email
 					try mimemail:decode(Data) of
 						_Result ->
 							?log(info, "Message decoded successfully!~n")
@@ -171,10 +232,9 @@ handle_DATA(From, To, Data, State) ->
 								end
 							end
 					end
-			end
-	end,
-	% At this point, if we return ok, we've accepted responsibility for the email
-	{ok, Reference, State}.
+			end,
+			queue_or_deliver(From, To, Data, Reference, State)
+	end.
 
 -spec handle_RSET(State :: #state{}) -> #state{}.
 handle_RSET(State) ->

--- a/src/smtp_server_example.erl
+++ b/src/smtp_server_example.erl
@@ -172,11 +172,11 @@ handle_RCPT_extension(Extension, _State) ->
 handle_DATA(_From, _To, <<>>, State) ->
 	{error, "552 Message too small", State};
 handle_DATA(From, To, Data, State) ->
-	% some kind of unique id
 	% if RELAY is true, then relay email to email address, else send email data to console
 	case proplists:get_value(relay, State#state.options, false) of
 		true -> relay(From, To, Data);
 		false ->
+			% some kind of unique id
 			Reference = lists:flatten([io_lib:format("~2.16.0b", [X]) || <<X>> <= erlang:md5(term_to_binary(unique_id()))]),
 			case proplists:get_value(parse, State#state.options, false) of
 				false -> ok;

--- a/test/gen_smtp_server_test.erl
+++ b/test/gen_smtp_server_test.erl
@@ -1,0 +1,15 @@
+-module(gen_smtp_server_test).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+invalid_lmtp_port_test_() ->
+	{"gen_smtp_server should prevent starting LMTP on port 25 (RFC2023, secion 5)",
+	 fun() ->
+		Options = [{port, 25}, {sessionoptions, [{protocol, lmtp}]}],
+		[?_assertMatch({error, invalid_lmtp_port},
+						 gen_smtp_server:start(gen_smtp_server, Options)),
+		?_assertError(invalid_lmtp_port,
+						gen_smtp_server:child_spec("LMTP Server", gen_smtp_server, Options))]
+	 end}.


### PR DESCRIPTION
Hello,

I would like to thank the maintainers for the amazing work and propose this PR as my attempt to add support for LMTP. This feature was requested in #196, and is something I find very appropriate, mainly because of the following reasons:

1. LMTP is a very similar protocol to SMTP. In practice it looks more of a variation of SMTP than a completely different protocol... Therefore it makes sense to implement both of them together and avoid code duplication between two different projects and code base.
2. Instead of dealing with the complexity of implementing robust and secure SMTP servers by themselves, a considerable part of developers prefer to deploy other battle-tested solution (with advanced features like anti-spam/anti-virus/grey listing integration like Postfix, OpenSMTPD and Exim) and only then place a custom LMTP server behind it.

The implementation I attempted follow more or less the guidelines stablished in #196 and any suggestions for improvement are welcome (in fact this is my very first time writing something in Erlang, so still learning...).

I have also implemented a proof of concept/integration test using OpenSMTPD and docker in https://github.com/abravalheri/lmtp_poc, and things seem to work fine.

Unfortunately I was not able to think in an easy solution for optimising the separation of concerns without requiring duplication of code, but if the maintainers have any ideas and would like to guide me in the process, I am open to go through more iterations of this PR.