### PR TITLE
Update README mimemail encode example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -114,7 +114,7 @@ SignedMailBody = \
                   [{<<"Subject">>, <<"DKIM testing">>},
                    {<<"From">>, <<"Andrew Thompson <andrew@hijacked.us>">>},
                    {<<"To">>, <<"Some Dude <foo@bar.com>">>}],
-                  [],
+                  #{},
                   <<"This is the email body">>},
                   [{dkim, DKIMOptions}]),
 gen_smtp_client:send({"whatever@example.com", ["andrew@hijacked.us"], SignedMailBody}, []).


### PR DESCRIPTION
Since Argument 2 of `mimemail:encode/3` requires a map and no longer a list, the README should reflect that