### PR TITLE
Accept tls options (specifically log_level)

### DIFF
--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -695,7 +695,12 @@ connect(Host, Options) ->
 		undefined -> [];
 		Other -> Other
 	end,
-	SockOpts = [binary, {packet, line}, {keepalive, true}, {active, false} | AddSockOpts],
+	AddTLSOpts = case proplists:get_value(tls_options, Options) of
+		undefined -> [];
+		TLSOpts -> TLSOpts
+	end,
+	AdditionalOpts = [binary, {packet, line}, {keepalive, true}, {active, false} | AddSockOpts],
+	SockOpts = [AdditionalOpts | AddTLSOpts],
 	Proto = case proplists:get_value(ssl, Options) of
 		true ->
 			ssl;

--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -700,7 +700,7 @@ connect(Host, Options) ->
 		TLSOpts -> TLSOpts
 	end,
 	AdditionalOpts = [binary, {packet, line}, {keepalive, true}, {active, false} | AddSockOpts],
-	SockOpts = [AdditionalOpts | AddTLSOpts],
+	SockOpts = AdditionalOpts ++ AddTLSOpts,
 	Proto = case proplists:get_value(ssl, Options) of
 		true ->
 			ssl;

--- a/src/smtp_socket.erl
+++ b/src/smtp_socket.erl
@@ -50,7 +50,7 @@
                               {versions, ['tlsv1', 'tlsv1.1', 'tlsv1.2']},
                               {port, 0}]).
 
--define(SSL_CONNECT_OPTIONS_KEYS, [ciphers]).
+-define(SSL_CONNECT_OPTIONS_KEYS, [ciphers, log_level]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
The latest [change to erlang's SSL](https://github.com/erlang/otp/pull/4805/files) module prints a warning when verify_none is used as a verify option. This function only prints at a log level of warning, so it is possible for users to choose when they want to see such warnings.

Accept TLS option for setting ssl_connection log_level.