### PR TITLE
Switch to SASL subprotocol on AUTH command

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -283,13 +283,9 @@ handle_info({SocketType, Socket, Packet}, #state{socket = Socket} = State)
 	%% We are in SASL state RFC-4954
 	Request = binstr:strip(binstr:strip(binstr:strip(binstr:strip(Packet, right, $\n), right, $\r), right, $\s), left, $\s),
 	?log(debug, "Got SASL request ~p", [Request]),
-	case handle_sasl(base64:decode(Request), State) of
-		{ok, NewState} ->
-			setopts(NewState, [{active, once}]),
-			{noreply, NewState, ?TIMEOUT};
-		{stop, Reason, NewState} ->
-			{stop, Reason, NewState}
-	end;
+	{ok, NewState} = handle_sasl(base64:decode(Request), State),
+	setopts(NewState, [{active, once}]),
+	{noreply, NewState, ?TIMEOUT};
 handle_info({Kind, _Socket}, State) when Kind == tcp_closed;
 										 Kind == ssl_closed ->
 	State1 = handle_error(Kind, [], State),

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -259,7 +259,7 @@ handle_info({receive_data, Body, Rest},
 			% might not even be able to get here anymore...
 			{noreply, State#state{readmessage = false, envelope = #envelope{}}, ?TIMEOUT}
 	end;
-handle_info({SocketType, Socket, Packet}, #state{socket = Socket, transport = Transport} = State)
+handle_info({SocketType, Socket, Packet}, #state{socket = Socket, transport = Transport, waitingauth = false} = State)
   when SocketType =:= tcp; SocketType =:= ssl ->
 	case handle_request(parse_request(Packet), State) of
 		{ok, #state{options = Options, readmessage = true, maxsize = MaxSize} = NewState} ->
@@ -272,6 +272,18 @@ handle_info({SocketType, Socket, Packet}, #state{socket = Socket, transport = Tr
 					  end,
 					  [link, {fullsweep_after, 0}]),
 			{noreply, NewState, ?TIMEOUT};
+		{ok, NewState} ->
+			setopts(NewState, [{active, once}]),
+			{noreply, NewState, ?TIMEOUT};
+		{stop, Reason, NewState} ->
+			{stop, Reason, NewState}
+	end;
+handle_info({SocketType, Socket, Packet}, #state{socket = Socket} = State)
+  when SocketType =:= tcp; SocketType =:= ssl ->
+	%% We are in SASL state RFC-4954
+	Request = binstr:strip(binstr:strip(binstr:strip(binstr:strip(Packet, right, $\n), right, $\r), right, $\s), left, $\s),
+	?log(debug, "Got SASL request ~p", [Request]),
+	case handle_sasl(base64:decode(Request), State) of
 		{ok, NewState} ->
 			setopts(NewState, [{active, once}]),
 			{noreply, NewState, ?TIMEOUT};
@@ -331,12 +343,7 @@ parse_request(Packet) ->
 	case binstr:strchr(Request, $\s) of
 		0 ->
 		    ?log(debug, "got a ~s request~n", [Request]),
-			case binstr:to_upper(Request) of
-				<<"QUIT">> = Res -> {Res, <<>>};
-				<<"DATA">> = Res -> {Res, <<>>};
-				% likely a base64-encoded client reply
-				UpperRequest -> {UpperRequest, <<>>}
-			end;
+			{binstr:to_upper(Request), <<>>};
 		Index ->
 			Verb = binstr:substr(Request, 1, Index - 1),
 			Parameters = binstr:strip(binstr:substr(Request, Index + 1), left, $\s),
@@ -479,43 +486,6 @@ handle_request({<<"AUTH">>, Args}, #state{extensions = Extensions, envelope = En
 					end
 			end
 	end;
-
-% the client sends a response to auth-cram-md5
-handle_request({Username64, <<>>}, #state{waitingauth = 'cram-md5', envelope = #envelope{auth = {<<>>, <<>>}}, authdata = AuthData} = State) ->
-	case binstr:split(base64:decode(Username64), <<" ">>) of
-		[Username, Digest] ->
-			try_auth('cram-md5', Username, {Digest, AuthData}, State#state{authdata=undefined});
-		_ ->
-			% TODO error
-			{ok, State#state{waitingauth=false, authdata=undefined}}
-	end;
-
-% the client sends a \0username\0password response to auth-plain
-handle_request({Username64, <<>>}, #state{waitingauth = 'plain', envelope = #envelope{auth = {<<>>,<<>>}}} = State) ->
-	case binstr:split(base64:decode(Username64), <<0>>) of
-		[_Identity, Username, Password] ->
-			try_auth('plain', Username, Password, State);
-		[Username, Password] ->
-			try_auth('plain', Username, Password, State);
-		_ ->
-			% TODO error
-			{ok, State#state{waitingauth=false}}
-	end;
-
-% the client sends a username response to auth-login
-handle_request({Username64, <<>>}, #state{waitingauth = 'login', envelope = #envelope{auth = {<<>>,<<>>}}} = State) ->
-	Envelope = State#state.envelope,
-	Username = base64:decode(Username64),
-	% smtp_socket:send(Socket, "334 " ++ base64:encode_to_string("Password:")),
-	send(State, "334 UGFzc3dvcmQ6\r\n"),
-	% store the provided username in envelope.auth
-	NewState = State#state{envelope = Envelope#envelope{auth = {Username, <<>>}}},
-	{ok, NewState};
-
-% the client sends a password response to auth-login
-handle_request({Password64, <<>>}, #state{waitingauth = 'login', envelope = #envelope{auth = {Username,<<>>}}} = State) ->
-	Password = base64:decode(Password64),
-	try_auth('login', Username, Password, State);
 
 handle_request({<<"MAIL">> = C, _Args}, #state{envelope = undefined, protocol = Protocol} = State) ->
 	send(State, ["503 Error: send ", lhlo_if_lmtp(Protocol, "HELO/EHLO"), " first\r\n"]),
@@ -739,6 +709,42 @@ handle_request({Verb, Args}, #state{module = Module, callbackstate = OldCallback
                 CState1
         end,
 	{ok, State#state{callbackstate = CallbackState}}.
+
+%% @doc handle SASL client response to `334' challenge - RFC-4954
+% the client sends a response to auth-cram-md5
+handle_sasl(UserDigest, #state{waitingauth = 'cram-md5', envelope = #envelope{auth = {<<>>, <<>>}}, authdata = AuthData} = State) ->
+	case binstr:split(UserDigest, <<" ">>) of
+		[Username, Digest] ->
+			try_auth('cram-md5', Username, {Digest, AuthData}, State#state{authdata=undefined});
+		_ ->
+			% TODO error
+			{ok, State#state{waitingauth=false, authdata=undefined}}
+	end;
+
+% the client sends a \0username\0password response to auth-plain
+handle_sasl(UserPass, #state{waitingauth = 'plain', envelope = #envelope{auth = {<<>>,<<>>}}} = State) ->
+	case binstr:split(UserPass, <<0>>) of
+		[_Identity, Username, Password] ->
+			try_auth('plain', Username, Password, State);
+		[Username, Password] ->
+			try_auth('plain', Username, Password, State);
+		_ ->
+			% TODO error
+			{ok, State#state{waitingauth=false}}
+	end;
+
+% the client sends a username response to auth-login
+handle_sasl(Username, #state{waitingauth = 'login', envelope = #envelope{auth = {<<>>,<<>>}}} = State) ->
+	Envelope = State#state.envelope,
+	% smtp_socket:send(Socket, "334 " ++ base64:encode_to_string("Password:")),
+	send(State, "334 UGFzc3dvcmQ6\r\n"),
+	% store the provided username in envelope.auth
+	NewState = State#state{envelope = Envelope#envelope{auth = {Username, <<>>}}},
+	{ok, NewState};
+
+% the client sends a password response to auth-login
+handle_sasl(Password, #state{waitingauth = 'login', envelope = #envelope{auth = {Username,<<>>}}} = State) ->
+	try_auth('login', Username, Password, State).
 
 -spec handle_error(error_class(), any(), #state{}) -> #state{}.
 handle_error(Kind, Details, #state{module=Module, callbackstate = OldCallbackState} = State) ->

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -335,7 +335,7 @@ parse_request(Packet) ->
 				<<"QUIT">> = Res -> {Res, <<>>};
 				<<"DATA">> = Res -> {Res, <<>>};
 				% likely a base64-encoded client reply
-				_ -> {Request, <<>>}
+				UpperRequest -> {UpperRequest, <<>>}
 			end;
 		Index ->
 			Verb = binstr:substr(Request, 1, Index - 1),
@@ -1102,7 +1102,8 @@ parse_request_test_() ->
 		},
 		{"Verbs should be uppercased",
 			fun() ->
-					?assertEqual({<<"HELO">>, <<"hell.af.mil">>}, parse_request(<<"helo hell.af.mil">>))
+					?assertEqual({<<"HELO">>, <<"hell.af.mil">>}, parse_request(<<"helo hell.af.mil">>)),
+					?assertEqual({<<"RSET">>, <<>>}, parse_request(<<"rset\r\n">>))
 			end
 		},
 		{"Leading and trailing spaces are removed",


### PR DESCRIPTION
I noticed that Python's [SMTPLIB](https://docs.python.org/3/library/smtplib.html) sends all verbs in lowercase and gen_smtp fails to recognize `rset\r\n` command.

UPD: while digging deeper, I found https://datatracker.ietf.org/doc/html/rfc4954 and it says that `AUTH xxxx` verb actually makes client/server switch to a SASL subprotocol which uses base64-encoded data exchange. So, it does not make sense to use the same `handle_request`/`parse_request` functions as the ones we use for regular SMTP.
RFC also says that client may interrupt SASL subprotocol by sending `*\r\n`, but I'm not implementing this feature here.