### PR TITLE
Replace RFC-822 address-list parser with RFC-5322

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build
 .eunit/
 ebin/gen_smtp.app
 src/smtp_rfc822_parse.erl
+src/smtp_rfc5322_scan.erl
+src/smtp_rfc5322_parse.erl
 deps/
 _build
 .rebar

--- a/src/smtp_rfc5322_parse.yrl
+++ b/src/smtp_rfc5322_parse.yrl
@@ -1,0 +1,104 @@
+%% @doc Parser for [[https://datatracker.ietf.org/doc/html/rfc5322#section-3.4]] "mailbox-list" structure
+
+Terminals
+    qstring
+    domain_literal
+    atom
+    '<'
+    '>'
+    ','
+    '@'
+    '.'
+    ':'
+    ';'.
+Nonterminals
+    root
+    mailbox_list
+    group
+    mailbox
+    name_addr
+    addr_spec
+    angle_addr
+    display_name
+    word
+    local_part
+    domain
+    dot_atom.
+
+Rootsymbol
+    root.
+
+root ->
+	mailbox_list : {mailbox_list, '$1'}.
+root ->
+	group : {group, '$1'}.
+
+group ->
+	display_name ':' ';' : {'$1', []}.
+group ->
+	display_name ':' mailbox_list ';' : {'$1', '$3'}.
+
+mailbox_list ->
+	mailbox : ['$1'].
+mailbox_list ->
+	mailbox ',' mailbox_list : ['$1' | '$3'].
+
+mailbox -> name_addr : '$1'.
+mailbox -> addr_spec : {undefined, '$1'}.
+
+name_addr ->
+	angle_addr : {undefined, '$1'}.
+name_addr ->
+	display_name angle_addr : {'$1', '$2'}.
+
+angle_addr ->
+	'<' addr_spec '>' : '$2'.
+
+addr_spec ->
+	local_part '@' domain : {addr, '$1', '$3'}.
+
+local_part ->
+	dot_atom : '$1'.
+local_part ->
+	qstring : value_of('$1').
+
+display_name ->
+	word : '$1'.
+display_name ->
+	word display_name : '$1' ++ " " ++ '$2'.
+
+word ->
+	dot_atom : '$1'.
+word ->
+	qstring : unescape(value_of('$1')).	% same as local_part, but with unescaping (is it necessary?)
+
+domain ->
+	dot_atom : '$1'.
+domain ->
+	domain_literal : value_of('$1').
+
+dot_atom ->
+	atom : value_of('$1').
+dot_atom ->
+	atom '.' dot_atom : value_of('$1') ++ "." ++ '$3'.
+
+Erlang code.
+-ignore_xref([{smtp_rfc5322_parse, return_error, 2}]).
+
+%% Unescaping
+unescape([$\\, C | Tail]) ->
+	%% unescaping
+	[C | unescape(Tail)];
+unescape([$" | Tail]) ->
+	%% stripping quotes (only possible at start and end)
+	unescape(Tail);
+unescape([C | Tail]) ->
+	[C | unescape(Tail)];
+unescape([]) -> [].
+
+
+value_of(Token) ->
+    try element(3, Token)
+    catch error:badarg ->
+            error({badarg, Token})
+    end.

--- a/src/smtp_rfc5322_scan.xrl
+++ b/src/smtp_rfc5322_scan.xrl
@@ -1,0 +1,36 @@
+%% @doc Lexer for [[https://datatracker.ietf.org/doc/html/rfc5322#section-3.4]] "mailbox-list" structure
+%% With unicode support from [[https://datatracker.ietf.org/doc/html/rfc6532]].
+%% It's a bit more permissive compared to the one proposed in RFC.
+%% It operates on codepoints! Not bytes! Use `unicode:characters_to_list/1'
+
+Definitions.
+%% Codepoint ranges which fit in 2/3/4 bytes of UTF-8; rfc3629#section-4
+UTF8_2 = [\x{80}-\x{7FF}]
+UTF8_3 = [\x{800}-\x{D7FF}\x{E000}-\x{FFFD}]
+UTF8_4 = [\x{10000}-\x{10FFFF}]
+
+Rules.
+
+[\s\t]+ : skip_token.
+
+%% rfc5322#section-3.2.5
+%% Anything between double quotes, but double quotes inside should be escaped
+"([^\"]|\\\")+" : {token, {qstring, TokenLine, TokenChars}}.
+
+%% rfc5322#section-3.4.1
+%% Anything between brackets, but closing bracket inside should be escaped
+\[([^\]]|\\\])+\] : {token, {domain_literal, TokenLine, TokenChars}}.
+
+%% rfc5322#section-3.2.3
+([0-9a-zA-Z!#\$\%&\'*+\-/=?^_`\{|\}~]|{UTF8_2}|{UTF8_3}|{UTF8_4})+ : {token, {atom, TokenLine, TokenChars}}.
+
+\< : {token, {'<', TokenLine}}.
+\> : {token, {'>', TokenLine}}.
+\, : {token, {',', TokenLine}}.
+@ : {token, {'@', TokenLine}}.
+\. : {token, {'.', TokenLine}}.
+% mailbox group
+\: : {token, {':', TokenLine}}.
+\; : {token, {';', TokenLine}}.
+
+Erlang code.

--- a/src/smtp_rfc822_parse.yrl
+++ b/src/smtp_rfc822_parse.yrl
@@ -24,6 +24,7 @@ address -> '<' email '>' : {undefined, '$2'}.
 address -> names '<' email '>' : {lists:flatten('$1'), '$3'}.
 
 email -> string : element(3, '$1').
+
 names -> name : '$1'.
 names -> name names : ['$1', " " | '$2'].
 name -> string : element(3, '$1').

--- a/test/gen_smtp_util_test.erl
+++ b/test/gen_smtp_util_test.erl
@@ -1,3 +1,4 @@
+%% coding: utf-8
 -module(gen_smtp_util_test).
 
 -compile([export_all, nowarn_export_all]).
@@ -8,42 +9,72 @@ test_test() ->
     smtp_util:parse_rfc822_addresses("foo bar").
 
 parse_rfc822_addresses_test_() ->
-    [
-     {"Empty address list",
+	F = fun smtp_util:parse_rfc822_addresses/1,
+	[{"Empty address list parse_rfc2822_addresses_test",
       fun() ->
-              ?assertEqual({ok, []}, smtp_util:parse_rfc822_addresses(<<>>)),
-              ?assertEqual({ok, []}, smtp_util:parse_rfc822_addresses(<<"   ">>)),
-              ?assertEqual({ok, []}, smtp_util:parse_rfc822_addresses(<<" \r\n\t  ">>)),
-              ?assertEqual({ok, []}, smtp_util:parse_rfc822_addresses(<<"
+              ?assertEqual({ok, []}, F(<<>>)),
+              ?assertEqual({ok, []}, F(<<"   ">>)),
+              ?assertEqual({ok, []}, F(<<" \r\n\t  ">>)),
+              ?assertEqual({ok, []}, F(<<"
 ">>))
       end},
-     {"Single addresses",
+	 {"Group parse_rfc2822_addresses_test",
+	  fun() ->
+			  %% XXX: this is incorrect...
+			  ?assertEqual({ok, [{undefined, "undisclosed-recipients:;"}]},
+						   F(<<"undisclosed-recipients:;">>))
+	  end},
+	 {"Multiple with comma  parse_rfc2822_addresses_test",
+	  fun() ->
+			  ?assertEqual({ok, [{"Jan", "a,a@a.com"}, {undefined, "b@b.com"}]},
+                           F(<<"Jan <a,a@a.com>,b@b.com">>))
+
+	  end}| parse_adresses_t(F)].
+
+parse_rfc2822_addresses_test_() ->
+	F = fun smtp_util:parse_rfc5322_addresses/1,
+	[{"Group parse_rfc822_addresses_test",
+	  fun() ->
+			  %% rfc5322#section-3.4
+			  %% empty group
+			  ?assertEqual({ok, []},
+						   F(<<"undisclosed-recipients:;">>)),
+			  %% group with recipient list
+			  ?assertEqual({ok, [{undefined, "a@a.com"}, {undefined, "b@b.com"}]},
+						  F(<<"friends:a@a.com,b@b.com;">>))
+	  end} | parse_adresses_t(F)].
+
+parse_adresses_t(F) ->
+	{_, FName} = erlang:fun_info(F, name),
+	FStr = atom_to_list(FName),
+    [
+     {"Single addresses " ++ FStr,
       fun() ->
               ?assertEqual({ok, [{undefined, "john@doe.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"john@doe.com">>)),
+                           F(<<"john@doe.com">>)),
               ?assertEqual({ok, [{"Fræderik Hølljen", "me@example.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"Fræderik Hølljen <me@example.com>">>)),
+                           F(<<"Fræderik Hølljen <me@example.com>"/utf8>>)),
               ?assertEqual({ok, [{undefined, "john@doe.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"<john@doe.com>">>)),
+                           F(<<"<john@doe.com>">>)),
               ?assertEqual({ok, [{"John", "john@doe.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"John <john@doe.com>">>)),
+                           F(<<"John <john@doe.com>">>)),
               ?assertEqual({ok, [{"John Doe", "john@doe.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"John Doe <john@doe.com>">>)),
+                           F(<<"John Doe <john@doe.com>">>)),
               ?assertEqual({ok, [{"John Doe", "john@doe.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"\"John Doe\" <john@doe.com>">>)),
+                           F(<<"\"John Doe\" <john@doe.com>">>)),
               ?assertEqual({ok, [{"John \"Mighty\" Doe", "john@doe.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"\"John \\\"Mighty\\\" Doe\" <john@doe.com>">>))
+                           F(<<"\"John \\\"Mighty\\\" Doe\" <john@doe.com>">>))
       end},
-     {"Multiple addresses",
+     {"Multiple addresses " ++ FStr,
       fun() ->
               ?assertEqual({ok, [{undefined, "a@a.com"}, {undefined, "b@b.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"a@a.com,b@b.com">>)),
-              ?assertEqual({ok, [{undefined, "a,a@a.com"}, {undefined, "b@b.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"<a,a@a.com>,b@b.com">>)),
-              ?assertEqual({ok, [{"Jan", "a,a@a.com"}, {undefined, "b@b.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"Jan <a,a@a.com>,b@b.com">>)),
-              ?assertEqual({ok, [{"Jan", "a,a@a.com"}, {"Berend Botje", "b@b.com"}]},
-                           smtp_util:parse_rfc822_addresses(<<"Jan <a,a@a.com>,\"Berend Botje\" <b@b.com>">>))
+                           F(<<"a@a.com,b@b.com">>)),
+              ?assertEqual({ok, [{undefined, "a@a.com"}, {undefined, "b@b.com"}]},
+                           F(<<"<a@a.com>,b@b.com">>)),
+              ?assertEqual({ok, [{"Jan", "a@a.com"}, {undefined, "b@b.com"}]},
+                           F(<<"Jan <a@a.com>,b@b.com">>)),
+              ?assertEqual({ok, [{"Jan", "a@a.com"}, {"Berend Botje", "b@b.com"}]},
+                           F(<<"Jan <a@a.com>,\"Berend Botje\" <b@b.com>">>))
       end}
     ].
 

--- a/test/prop_rfc5322.erl
+++ b/test/prop_rfc5322.erl
@@ -1,0 +1,219 @@
+%% @doc property-based tests for `smtp_util' rfc5322#section-3.4 and RFC-822 parser/serializer
+%% Mainly tests parsing of address-lists and groups:
+%% `login@domain'
+%% `Name <login@domain>'
+%% `Name Surname <login@domain>'
+%% `Name <login1@domain1>, Name2 <login2@domain2>'
+%% `group name:login@domain,Name <login2@domain2>;'
+%% Also different versions of escaping of name / login / domain
+-module(prop_rfc5322).
+
+-export([
+	prop_encode_no_crash/1,
+	prop_encode_scan_no_crash/1,
+	prop_encode_decode_match/1,
+	prop_encode_decode_group/1
+]).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+prop_encode_no_crash(doc) ->
+    "Check that any RFC-5322-compliant 'mailbox-list' can be serialized".
+
+prop_encode_no_crash() ->
+    ?FORALL(
+       AddressList,
+       ?LET(Opts, use_unicode(), gen_address_list(Opts)),
+       is_binary(smtp_util:combine_rfc822_addresses(AddressList))
+    ).
+
+prop_encode_scan_no_crash(doc) ->
+    "Check that any RFC-5322-compliant 'mailbox-list' can be serialized and then result scanned by lexer".
+
+prop_encode_scan_no_crash() ->
+    ?FORALL(
+       AddressList,
+       ?LET(Opts, use_unicode(), gen_address_list(Opts)),
+	   begin
+		   Encoded = smtp_util:combine_rfc822_addresses(AddressList),
+		   Res = smtp_rfc5322_scan:string(unicode:characters_to_list(Encoded)),
+		   ?WHENFAIL(
+			  io:format("AddrList:~n~p~nEncoded:~n~p~nRes:~n~p~n",
+						[AddressList, Encoded, Res]),
+			  begin
+				  ?assertMatch({ok, _, 1}, Res),
+				  true
+			  end)
+	   end
+    ).
+
+prop_encode_decode_match(doc) ->
+    "Check that any RFC-5322-compliant 'mailbox-list' can be serialized and parsed to the same result".
+
+prop_encode_decode_match() ->
+    ?FORALL(
+       AddressList,
+       ?LET(Opts, use_unicode(), gen_address_list(Opts)),
+	   begin
+		   Encoded = smtp_util:combine_rfc822_addresses(AddressList),
+		   Res = smtp_util:parse_rfc5322_addresses(Encoded),
+		   ?WHENFAIL(
+			  io:format("AddrList:~n~p~nEncoded:~n~p~nRes:~n~p~nScan:~n~p~n",
+						[AddressList, Encoded, Res,
+						 smtp_rfc5322_scan:string(unicode:characters_to_list(Encoded))]),
+			  begin
+				  {ok, Decoded} = Res,
+				  Zip = lists:zip(AddressList, Decoded),
+				  lists:all(fun match/1, Zip)
+			  end)
+	   end
+    ).
+
+match({{OName, OAddr}, {undefined, RAddr}}) when OName == undefined;
+												 OName == <<>>;
+												 OName == "" ->
+	?assertEqual(OAddr, unicode:characters_to_binary(RAddr)),
+	true;
+match({{OName, OAddr}, {RName, RAddr}}) ->
+	%% smtp_util drops chars below 32 from "name" part. Not sure it's correct, but is probably
+	%% not a big deal.
+	ONameNoControl = lists:map(
+					   fun(C) when C < 32 -> 32;
+						  (C) -> C
+					   end,
+					   unicode:characters_to_list(OName)),
+	?assertEqual(ONameNoControl, RName),
+	?assertEqual(OAddr, unicode:characters_to_binary(RAddr)),
+	true.
+
+prop_encode_decode_group(doc) ->
+	"Check that any RFC-5322-compliant 'group' can be serialized and parsed to the same result".
+
+prop_encode_decode_group() ->
+    ?FORALL(
+       {Name, AddressList},
+       ?LET(Opts, use_unicode(), gen_group(Opts)),
+	   begin
+		   Encoded = encode_group(Name, AddressList),
+		   {ok, Tokens, _} = smtp_rfc5322_scan:string(unicode:characters_to_list(Encoded)),
+		   Res = smtp_rfc5322_parse:parse(Tokens),
+		   ?WHENFAIL(
+			  io:format("Name: '~p'~n"
+						"AddressList: ~p~n"
+						"Encoded: ~p~n"
+						"Res: ~p~n",
+						[Name, AddressList, Encoded, Res]),
+			  begin
+				  ?assertMatch({ok, {group, {_, _}}}, Res),
+				  {ok, {group, {ResName, ResList0}}} = Res,
+				  ResList =
+					  lists:map(fun({AName, {addr, Local, Domain}}) ->
+										{AName, Local ++ "@" ++ Domain}
+								end, ResList0),
+				  ?assertEqual(unicode:characters_to_list(Name), ResName),
+				  lists:all(fun match/1, lists:zip(AddressList, ResList))
+			  end)
+	   end).
+
+encode_group(Name, AddressList) ->
+	EncodedList = smtp_util:combine_rfc822_addresses(AddressList),
+	EncName = case binary:match(Name, <<"\"">>) of
+				  nomatch -> Name;
+				  _ ->
+					  <<$\", (binary:replace(Name, <<"\"">>, <<"\\\"">>, [global]))/binary, $\">>
+			  end,
+	<<EncName/binary, ":", EncodedList/binary, ";">>.
+
+use_unicode() ->
+	proper_types:oneof(
+	 [#{}, #{}, #{unicode => true}
+	 ]).
+
+gen_group(Opts) ->
+	{gen_phrase(Opts),
+	 proper_types:oneof(
+	   [gen_address_list(Opts),
+		[]										%group might be empty
+	   ])}.
+
+gen_address_list(Opts) ->
+	proper_types:non_empty(
+	  proper_types:list(
+		proper_types:oneof(
+		  [gen_anonymous_name_addr(Opts),
+		   gen_named_name_addr(Opts)
+		  ])
+	   )).
+
+gen_anonymous_name_addr(Opts) ->
+	{proper_types:oneof(
+	  ["", <<>>, undefined]),
+	 gen_addr_spec(Opts)}.
+
+gen_named_name_addr(Opts) ->
+	{gen_phrase(Opts), gen_addr_spec(Opts)}.
+
+-define(NO_WS_CTL, (lists:seq(1, 8) ++ [11, 12] ++ lists:seq(14, 31) ++ [127])).
+
+%% rfc5322#section-3.4
+gen_addr_spec(Opts) ->
+	?LET({Local, Domain},
+		 {gen_local_part(Opts), gen_domain(Opts)},
+		 <<Local/binary, "@", Domain/binary>>).
+
+gen_local_part(Opts) ->
+	proper_types:oneof(
+	  [gen_dot_atom(Opts), gen_quoted_string(Opts)]).
+
+gen_domain(Opts) ->
+	proper_types:oneof(
+	  [gen_dot_atom(Opts), gen_domain_literal(Opts)]
+	 ).
+
+gen_domain_literal(Opts) ->
+	DText = maybe_utf8(?NO_WS_CTL ++ lists:seq(33, 90) ++ lists:seq(94, 126), Opts),
+	DContent = proper_types:oneof([<<"\\[">>, <<"\\]">> | DText]),
+	?LET(Str,
+		 proper_types:non_empty(proper_types:list(DContent)),
+		 <<"[", (unicode:characters_to_binary(Str))/binary, "]">>).
+
+%% rfc5322#section-3.2.5
+gen_phrase(Opts) ->
+	Word = proper_types:oneof(
+			 [gen_atom(Opts),
+			  gen_quoted_string(Opts)]
+			),
+	?LET(Words,
+		 proper_types:non_empty(proper_types:list(Word)),
+		 unicode:characters_to_binary(lists:join($\s, Words))).
+
+%% rfc5322#section-3.2.5
+gen_quoted_string(Opts) ->
+	QText = maybe_utf8(?NO_WS_CTL ++ [33] ++ lists:seq(35, 91) ++ lists:seq(93, 126), Opts),
+	%% QContent = [<<"\\\"">> | QText],
+	QContent = QText,
+	?LET(Str,
+         proper_types:non_empty(proper_types:list(proper_types:oneof(QContent))),
+		 unicode:characters_to_binary([$\", Str, $\"])).
+
+%% rfc5322#section-3.2.3
+gen_dot_atom(Opts) ->
+	?LET(Parts,
+		 proper_types:non_empty(proper_types:list(gen_atom(Opts))),
+		 unicode:characters_to_binary(lists:join($\., Parts))).
+
+gen_atom(Opts) ->
+	Spec = "!#$%&'*+-/=?^_`{|}~",
+	Atext = maybe_utf8(lists:seq($0, $9) ++ lists:seq($A, $Z) ++ lists:seq($a, $z) ++ Spec, Opts),
+	?LET(Str, proper_types:non_empty(proper_types:list(proper_types:oneof(Atext))),
+		 unicode:characters_to_binary(Str)).
+
+maybe_utf8(Chars, #{unicode := true}) ->
+	%% See `proper_unicode.erl'
+	[proper_types:integer(16#80, 16#7FF),
+	 proper_types:integer(16#800, 16#D7FF), proper_types:integer(16#E000, 16#FFFD),
+	 proper_types:integer(16#10000, 16#10FFFF),
+	 proper_types:oneof(Chars)];
+maybe_utf8(Chars, _) ->
+	Chars.


### PR DESCRIPTION
A more modern and robust parser for address specifiers like this (may appear in To / From / CC etc):
https://datatracker.ietf.org/doc/html/rfc5322#section-3.4

-  `login@domain`
- `Name <login@domain>`
- `Name Surname <login@domain>`
- `Name <login1@domain1>, Name2 <login2@domain2>`
- `group name:login@domain,Name <login2@domain2>;`

 Also different versions of escaping of name / login / domain.
It's much more unicode-friendly also.