### PR TITLE
Use SPDX ID for licenses

### DIFF
--- a/src/gen_smtp.app.src
+++ b/src/gen_smtp.app.src
@@ -3,6 +3,6 @@
               {vsn,"1.1.1"},
               {applications,[kernel,stdlib,crypto,asn1,public_key,ssl,ranch]},
               {registered,[]},
-              {licenses,["BSD 2-clause"]},
+              {licenses,["BSD-2-Clause"]},
               {links,[{"GitHub","https://github.com/gen-smtp/gen_smtp"}]},
               {exclude_files,["src/smtp_rfc822_parse.erl"]}]}.


### PR DESCRIPTION
Hex.pm recommends this, and it helps tools identify exactly which BSD license this project is released under.