### PR TITLE
Fix CI doc to run on master again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,10 +3,10 @@ name: Doc
 on:
   push:
     branches:
-      - $default-branch
+      - master
   pull_request:
     branches:
-      - $default-branch
+      - master
 
 jobs:
 


### PR DESCRIPTION
$default-branch is only available in templates.