### PR TITLE
Improve and fix header encoding

### DIFF
--- a/test/gen_smtp_util_test.erl
+++ b/test/gen_smtp_util_test.erl
@@ -115,8 +115,6 @@ rfc822_addresses_roundtrip_test() ->
 
 rfc2047_utf8_encode_test() ->
     UnicodeString = unicode:characters_to_binary("€ € € € € 1234 € € € € 123 € € € € € 1234€"),
-    Encoded = "=?UTF-8?Q?=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20123?=\r\n"
-            ++ " =?UTF-8?Q?4=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20123=20?=\r\n"
-            ++ " =?UTF-8?Q?=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20=E2=82=AC=20123?=\r\n"
-            ++ " =?UTF-8?Q?4=E2=82=AC?=",
+    Encoded = << "=?UTF-8?B?4oKsIOKCrCDigqwg4oKsIOKCrCAxMjM0IOKCrCDigqwg4oKsIOKCrCAxMjMg?=\r\n"
+		" =?UTF-8?B?4oKsIOKCrCDigqwg4oKsIOKCrCAxMjM04oKs?=">>,
     ?assertEqual(Encoded, mimemail:rfc2047_utf8_encode(UnicodeString)).


### PR DESCRIPTION
Having done #292 before, I expected this to be smooth sailing, but, boy... 🤯 Thanks @juhlig for helping 🤗
Ok, here goes.

* The current implementation uses list operations, a lot of list reversals and expensive concatenations (`++`).
  This PR uses binary operations and works without reversing.

* The RFC2047 header encoding is incorrect in the current implementation. As it is used, among others, to encode phrases preceding an address (like in `From`-headers), the restrictions of [RFC2047 Section 5](https://datatracker.ietf.org/doc/html/rfc2047#section-5) (3) should apply, and so only lower- and uppercase ASCII characters, decimal digits, and the characters `!`, `*`, `+`, `-` and `-` are allowed to appear (unescaped) in a Q-Encoded word text there.
  This PR encodes characters according to the mentioned RFC2047 Section 5 (3) when Q-Encoding is used.

* The current implementation encodes spaces as `=20` in Q-Encoding, which is allowed, but for reasons of readability, it is also allowed (and more common) to encode spaces as `_` (underscore).
  This PR encodes spaces as `_` when Q-Encoding is used.

* The current implementation encodes everything with Q-Encoding, which is good for readability. However, if most of the value to be encoded is _not_ printable ASCII, the B-Encoding is a better option.
  This PR selects Q- or B-Encoding, for the entire header value. Though it is possible to decide encoding for each encoded word individually, it is more confusing than it is worth.

* The current implementation has a bug in Q-Decoding headers. It replacses `_` with spaces before passing it to the Quoted-Printable decoder. If the `_` was in the last position of an Q-Encoded word text, the Quoted-Printable decoder will drop the space(s), as it is supposed to do.
  This PR replaces `_` with `=20` before decoding.