### PR TITLE
Mimemail parameters fixes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- mode: erlang; -*-
-{require_min_otp_vsn, "19"}.
+{require_min_otp_vsn, "21"}.
 
 {erl_opts,
  [fail_on_warning,

--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -337,15 +337,16 @@ decode_component(_Headers, _Body, Other, _Options) ->
 %% @doc Do a case-insensitive header lookup to return that header's value, or the specified default.
 get_header_value(Needle, Headers, Default) ->
 	?log(debug, "Headers: ~p~n", [Headers]),
+	NeedleLower = binstr:to_lower(Needle),
 	F =
 	fun({Header, _Value}) ->
-			binstr:to_lower(Header) =:= binstr:to_lower(Needle)
+			binstr:to_lower(Header) =:= NeedleLower
 	end,
-	case lists:filter(F, Headers) of
+	case lists:search(F, Headers) of
 		% TODO if there's duplicate headers, should we use the first or the last?
-		[{_Header, Value}|_T] ->
+		{value, {_Header, Value}} ->
 			Value;
-		_ ->
+		false ->
 			Default
 	end.
 


### PR DESCRIPTION
Noticed that in some specific case `mimemail:mimetuple()`'s 4th element which is supposed to always be `mimemail:parameters()` map, it is actually returned as a list (of incorrect values anyway) from `decode/1`.

Fixed it, also added some more proper-tests validation for `parameters()`.

Small bonus: some optimization in `mimemail:get_header_value/2,3`