### PR TITLE
Generating docs with ExDoc instead of EDoc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,10 +8,10 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{config,src}]
+[*.{config, src}]
 indent_style = space
 
-[*.{md,markdown}]
+[*.md]
 indent_style = space
 trim_trailing_whitespace = false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         otp: ["24", "23", "22"]
-        rebar3: ["3.17.0"]
+        rebar3: ["3.18.0"]
         profile: [test, ranch_v2]
         include:
           - os: ubuntu-latest
@@ -50,6 +50,9 @@ jobs:
 
       - name: Xref
         run: make xref
+
+      - name: Format
+        run: rebar3 fmt --check
 
       - name: Test
         run: make test REBAR_PROFILE=${{ matrix.profile }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Doc
+name: Docs
 
 on:
   push:
@@ -11,14 +11,14 @@ on:
 jobs:
 
   docs:
-    name: Build EDoc on OTP ${{ matrix.otp }}
+    name: Generate docs on OTP ${{ matrix.otp }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest]
-        otp: ["24"]
-        rebar3: ["3.17.0"]
+        otp: ["24"] # https://www.erlang.org/downloads
+        rebar3: ["3.18.0"] # https://www.rebar3.org
 
     steps:
       - uses: actions/checkout@v2
@@ -35,5 +35,5 @@ jobs:
           key: ${{ runner.os }}-hex-${{ hashFiles('**/rebar.lock') }}
           restore-keys: ${{ runner.os }}-hex-
 
-      - name: Build EDoc
-        run: make docs
+      - name: Generate docs by ExDoc
+        run: rebar3 ex_doc

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ dialyze:
 xref:
 	rebar3 as test xref
 
+format:
+	rebar3 fmt
+
 docs:
 	rebar3 edoc
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean:
 	@rebar3 clean -a
 
 test:
-	ERL_AFLAGS="-s ssl" 
+	ERL_AFLAGS="-s ssl"
 	rebar3 as $(REBAR_PROFILE) eunit -c
 
 proper:
@@ -27,6 +27,6 @@ format:
 	rebar3 fmt
 
 docs:
-	rebar3 edoc
+	rebar3 ex_doc
 
 .PHONY: compile clean test dialyze

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # gen_smtp
 
 [![Hex pm](http://img.shields.io/hexpm/v/gen_smtp.svg?style=flat)](https://hex.pm/packages/gen_smtp)
-[![CI](https://github.com/gen-smtp/gen_smtp/workflows/CI/badge.svg)](https://github.com/gen-smtp/gen_smtp/actions?query=workflow%3ACI)
-[![Documentation](https://github.com/gen-smtp/gen_smtp/workflows/Documentation/badge.svg)](https://github.com/gen-smtp/gen_smtp/actions?query=workflow%3ADocumentation)
+[![CI](https://github.com/gen-smtp/gen_smtp/actions/workflows/ci.yml/badge.svg)](https://github.com/gen-smtp/gen_smtp/actions/workflows/ci.yml)
+[![Docs](https://github.com/gen-smtp/gen_smtp/actions/workflows/docs.yml/badge.svg)](https://github.com/gen-smtp/gen_smtp/actions/workflows/docs.yml)
 
 The Erlang SMTP client and server library.
 

--- a/rebar.config
+++ b/rebar.config
@@ -20,8 +20,10 @@
 
 {project_plugins, [
     erlfmt,
+    rebar3_ex_doc,
     rebar3_proper
 ]}.
+
 {erlfmt, [
     write,
     {print_width, 120},
@@ -72,4 +74,13 @@
             {proper, "1.3.0"}
         ]}
     ]}
+]}.
+
+{ex_doc, [
+    {source_url, <<"https://github.com/gen-smtp/gen_smtp">>},
+    {extras, [
+        {'README.md', [{title, <<"Overview">>}]},
+        {'LICENSE', [{title, <<"License">>}]}
+    ]},
+    {main, <<"readme">>}
 ]}.

--- a/src/gen_smtp.app.src
+++ b/src/gen_smtp.app.src
@@ -1,6 +1,6 @@
 {application, gen_smtp, [
     {description, "The extensible Erlang SMTP client and server library."},
-    {vsn, "1.1.1"},
+    {vsn, "1.2.0-dev"},
     {applications, [kernel, stdlib, crypto, asn1, public_key, ssl, ranch]},
     {registered, []},
     {licenses, ["BSD-2-Clause"]},

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -89,16 +89,7 @@
     options = [] :: [tuple()]
 }).
 
-%% OTP-19: ssl:ssl_option()
-%% OTP-20: ssl:ssl_option()
-%% OTP-21: ssl:tls_server_option()
-%% OTP-22: ssl:tls_server_option()
-%% OTP-23: ssl:tls_server_option()
--ifdef(OTP_RELEASE).
 -type tls_opt() :: ssl:tls_server_option().
--else.
--type tls_opt() :: ssl:ssl_option().
--endif.
 
 -type options() :: [
     {callbackoptions, any()}

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -170,7 +170,6 @@
 -optional_callbacks([handle_info/2, handle_AUTH/4, handle_error/3]).
 
 %% @doc Start a SMTP session linked to the calling process.
-%% @see start/3
 -spec start_link(
     Ref :: ranch:ref(),
     Transport :: module(),


### PR DESCRIPTION
Clean new PR replacing https://github.com/gen-smtp/gen_smtp/pull/290.

---

Additionally this PR removes code meant for < OTP 21.
Additionally this PR introduces format checking in CI.
This part is probably opinionated if task should be allowed to fail
until every maintainer is used to check the format beforehand.

I've added the usage of `ex_doc` & `fmt` to the Makefile as a kind of documentation.
For myself it is not 100% clear how I could make sure I use the latest rebar3 plugin as they are not anywhere pinned.
-> [Upgrading Plugins](https://rebar3.readme.io/docs/using-available-plugins#upgrading-plugins)
This also means I'm not sure how reproducible the CI is regarding the plugins.

All the best.