### PR TITLE
Remove legacy OTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Session options are:
 * `{allow_bare_newlines, false | ignore | fix | strip}` - see above
 * `{hostname, inet:hostname()}` - which hostname server should send in response
   to `HELO` / `EHLO` commands. Default: `inet:gethostname()`.
-* `{tls_options, [ssl:server_option()]}` - options to pass to `ssl:handshake/3` (OTP-21+) / `ssl:ssl_accept/3`
+* `{tls_options, [ssl:server_option()]}` - options to pass to `ssl:handshake/3`
   when `STARTTLS` command is sent by the client. Only needed if `STARTTLS` extension
   is enabled
 * `{protocol, smtp | lmtp}` - when `lmtp` is passed, the control flow of the

--- a/src/smtp_socket.erl
+++ b/src/smtp_socket.erl
@@ -137,31 +137,10 @@ accept(Socket, Timeout) when is_port(Socket) ->
 accept(Socket, Timeout) ->
     case ssl:transport_accept(Socket, Timeout) of
         {ok, NewSocket} ->
-            ssl_handshake(NewSocket);
+            ssl:handshake(NewSocket);
         {error, _} = Error ->
             Error
     end.
-
--ifdef(OTP_RELEASE).
-ssl_handshake(Socket) ->
-    ssl:handshake(Socket).
-
-ssl_handshake(Socket, Options, Timeout) ->
-    ssl:handshake(Socket, Options, Timeout).
-
--else.
-ssl_handshake(Socket) ->
-    case ssl:ssl_accept(Socket) of
-        ok -> {ok, Socket};
-        {error, _} = Error -> Error
-    end.
-
-ssl_handshake(Socket, Options, Timeout) ->
-    case ssl:ssl_accept(Socket, Options, Timeout) of
-        {ok, _} = OK -> OK;
-        {error, _} = Error -> Error
-    end.
--endif.
 
 -spec send(Socket :: socket(), Data :: binary() | string() | iolist()) -> 'ok' | {'error', any()}.
 send(Socket, Data) when is_port(Socket) ->
@@ -276,7 +255,7 @@ to_ssl_server(Socket, Options) ->
     Socket :: socket(), Options :: list(), Timeout :: non_neg_integer() | 'infinity'
 ) -> {'ok', ssl:sslsocket()} | {'error', any()}.
 to_ssl_server(Socket, Options, Timeout) when is_port(Socket) ->
-    ssl_handshake(Socket, ssl_listen_options(Options), Timeout);
+    ssl:handshake(Socket, ssl_listen_options(Options), Timeout);
 to_ssl_server(_Socket, _Options, _Timeout) ->
     {error, already_ssl}.
 

--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -88,10 +88,8 @@ compute_cram_digest(Key, Data) ->
     Bin = hmac_md5(Key, Data),
     list_to_binary([io_lib:format("~2.16.0b", [X]) || <<X>> <= Bin]).
 
--ifdef(OTP_RELEASE).
 -if(?OTP_RELEASE >= 23).
 -define(CRYPTO_MAC, true).
--endif.
 -endif.
 
 -ifdef(CRYPTO_MAC).

--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -89,10 +89,6 @@ compute_cram_digest(Key, Data) ->
     list_to_binary([io_lib:format("~2.16.0b", [X]) || <<X>> <= Bin]).
 
 -if(?OTP_RELEASE >= 23).
--define(CRYPTO_MAC, true).
--endif.
-
--ifdef(CRYPTO_MAC).
 hmac_md5(Key, Data) ->
     crypto:mac(hmac, md5, Key, Data).
 -else.


### PR DESCRIPTION
As OTP < 21 is not supported anymore we can rely on `ssl:handshake/1` & `ssl:handshake/3`.