### PR TITLE
Add LMTP support to the gen_smtp_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The `send` method variants `send/2, send/3, send_blocking/2` take an `Options` a
   * **tls_options** used in `ssl:connect`, More info at http://erlang.org/doc/man/ssl.html . Defaults to `[{versions , ['tlsv1', 'tlsv1.1', 'tlsv1.2']}]`. This is merged with options listed at: https://github.com/gen-smtp/gen_smtp/blob/master/src/smtp_socket.erl#L46 . Any options not present in this list will be ignored.
   * **hostname** the hostname to be used by the smtp relay. Defaults to: `smtp_util:guess_FQDN()`. The hostname on your computer might not be correct, so set this to a valid value.
   * **retries** how many retries per smtp host on temporary failure. Defaults to 1, which means it will retry once if there is a failure.
+  * **protocol** valid values are `smtp`, `lmtp`. Default is `smtp`
 
 
 ### DKIM signing of outgoing emails

--- a/rebar.config
+++ b/rebar.config
@@ -77,8 +77,8 @@
 {ex_doc, [
     {source_url, <<"https://github.com/gen-smtp/gen_smtp">>},
     {extras, [
-        {'README.md', [{title, <<"Overview">>}]},
-        {'LICENSE', [{title, <<"License">>}]}
+        {'README.md', #{title => "Overview"}},
+        {'LICENSE', #{title => "License"}}
     ]},
     {main, <<"readme">>}
 ]}.


### PR DESCRIPTION
Hey team!

First of all, I would like to thank you guys for this exceptional work!
Second, I am proposing supporting LMTP in delivering messages.

It would be really useful in cases when it's needed to deliver messages to an LMTP server (ie, Dovecot)

Usage example:

```erlang
Socket = gen_smtp_client:open([{relay, "local-dovecot"}, {protocol, lmtp}])
gen_smtp_client:deliver(Socket, {"whatever@test.com", ["pablo@example.com"],
 "Subject: testing\r\nFrom: Andrew Thompson <andrew@hijacked.us>\r\nTo: Some Dude <foo@bar.com>\r\n\r\nThis is the email body"}).
```

I would love to receive suggestions to improve it. This is my first time writing Erlang code.

Thank you