### PR TITLE
Fix docs source links

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -76,6 +76,7 @@
 
 {ex_doc, [
     {source_url, <<"https://github.com/gen-smtp/gen_smtp">>},
+    {prefix_ref_vsn_with_v, false},
     {extras, [
         {'README.md', #{title => "Overview"}},
         {'LICENSE', #{title => "License"}}


### PR DESCRIPTION
Fix the source links, which are currently broken because `rebar3_ex_doc` [assumes the git tags are prefixed with v by default](https://github.com/starbelly/rebar3_ex_doc/pull/46).

Example: https://hexdocs.pm/gen_smtp/1.2.0/readme.html links to: https://github.com/gen-smtp/gen_smtp/blob/v1.2.0/README.md#L1 but it should be: https://github.com/gen-smtp/gen_smtp/blob/1.2.0/README.md#L1.