### PR TITLE
smtp_server_example: fix DATA response

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ DATA
 354 enter mail, end with line containing only '.'
 Good evening gentlemen, all your base are belong to us.
 .
-250 queued as #Ref<0.0.0.47>
+250 queued as d98ae19ee87f0741ac9ba90d7046f0c5
 QUIT
 221 Bye
 Connection closed by foreign host.

--- a/src/smtp_server_example.erl
+++ b/src/smtp_server_example.erl
@@ -345,7 +345,7 @@ queue_or_deliver(From, To, Data, Reference, State) ->
             ),
             % ... should actually handle the email,
             %     if `ok` is returned we are taking the responsibility of the delivery.
-            {ok, ["queued as ~s", Reference], State};
+            {ok, ["queued as ", Reference], State};
         lmtp ->
             ?LOG_INFO("message from ~s delivered to ~p, body length ~p", [From, To, Length], ?LOGGER_META),
             Multiple = [{ok, ["delivered to ", Recipient]} || Recipient <- To],


### PR DESCRIPTION
`["queued as ~s", Reference]` becomes like:

```
250 queued as ~sd98ae19ee87f0741ac9ba90d7046f0c5
```

I've fixed it to `["queued as ", Reference]` so that it looks like:

```
250 queued as d98ae19ee87f0741ac9ba90d7046f0c5
```