### PR TITLE
add tls_options to smtp:socket:connect/5 (erlang 26 fix)

### DIFF
--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -850,13 +850,14 @@ connect(Host, Options) ->
             undefined -> [];
             Other -> Other
         end,
-    SockOpts = [binary, {packet, line}, {keepalive, true}, {active, false} | AddSockOpts],
-    Proto =
+    SockOpts0 = [binary, {packet, line}, {keepalive, true}, {active, false} | AddSockOpts],
+    {Proto, SockOpts} =
         case proplists:get_value(ssl, Options) of
             true ->
-                ssl;
+                %% for ssl need to add tls_options to connect (see smtp_socket:connect/5)
+                {ssl, lists:append(SockOpts0, proplists:get_value(tls_options, Options, []))};
             _ ->
-                tcp
+                {tcp, SockOpts0}
         end,
     Port =
         case proplists:get_value(port, Options) of


### PR DESCRIPTION
One can provide e.g.
`{tls_options, [{verify, verify_none}]}`
to configuration to avoid problem introduced in erlang 26 (default `verify` is `verify_peer` now).
