### PR TITLE
Allow sender to immediately hangup after QUIT message

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        otp: ["24"] # https://www.erlang.org/downloads
+        otp: ["25"] # https://www.erlang.org/downloads
         rebar3: ["3.18.0"] # https://www.rebar3.org
 
     steps:

--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -898,7 +898,10 @@ read_possible_multiline_reply(Socket) ->
                     Code = binstr:substr(Packet, 1, 3),
                     read_multiline_reply(Socket, Code, [Packet]);
                 <<" ">> ->
-                    {ok, Packet}
+                    {ok, Packet};
+                _ ->
+                    quit(Socket),
+                    throw({unexpected_response, Packet})
             end;
         Error ->
             throw({network_failure, Error})

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -829,7 +829,7 @@ handle_request({<<"NOOP">>, _Any}, State) ->
     send(State, "250 Ok\r\n"),
     {ok, State};
 handle_request({<<"QUIT">>, _Any}, State) ->
-    send(State, "221 Bye\r\n"),
+    try_send(State, "221 Bye\r\n"),
     {stop, normal, State};
 handle_request(
     {<<"VRFY">>, Address},
@@ -1356,6 +1356,14 @@ check_bare_crlf(Binary, _Prev, Op, Offset) ->
                 false ->
                     Binary
             end
+    end.
+
+try_send(#state{transport = Transport, socket = Sock} = St, Data) ->
+    case Transport:send(Sock, Data) of
+        ok ->
+            ok;
+        {error, _Err} ->
+            ok
     end.
 
 send(#state{transport = Transport, socket = Sock} = St, Data) ->


### PR DESCRIPTION
This fixes a problem where the gen_smtp_server crashes if the client sends a QUIT message and immediately hangs up before the "221 Bye" can be send.  This is done by ignoring any send errors.

In the client:  be a bit more subtle when receiving funky multiline replies. Do not immediately crash but just throw an "unexpected_response" exception.

Use OTP 25 for docs build, as ex_doc requires it.