### PR TITLE
RFC-3030 (CHUNKING and BINARYMIME)

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -3250,7 +3250,7 @@ smtp_session_binarymime_test_() ->
                         {tcp, CSock, Packet4} -> smtp_socket:active_once(CSock)
                     end,
                     ?assertMatch("250 " ++ _, Packet4),
-                    RandomBytes = rand:bytes(32),
+                    RandomBytes = crypto:strong_rand_bytes(32),
                     smtp_socket:send(CSock, "BDAT 72\r\n"),
                     smtp_socket:send(CSock, "Subject: tls message\r\n"),
                     smtp_socket:send(CSock, "To: <user@otherhost>\r\n"),

--- a/src/smtp_server_example.erl
+++ b/src/smtp_server_example.erl
@@ -118,7 +118,14 @@ handle_EHLO(Hostname, Extensions, State) ->
             Size when is_integer(Size), Size > 0 ->
                 [{"SIZE", integer_to_list(Size)} | lists:keydelete("SIZE", 1, MyExtensions1)]
         end,
-    {ok, MyExtensions2, State}.
+    MyExtensions3 =
+        case proplists:get_value(binarymime, State#state.options) of
+            true ->
+                MyExtensions2 ++ [{"BINARYMIME", true}];
+            _Else ->
+                MyExtensions2
+        end,
+    {ok, MyExtensions3, State}.
 
 %% @doc Handle the MAIL FROM verb. The From argument is the email address specified by the
 %% MAIL FROM command. Extensions to the MAIL verb are handled by the `handle_MAIL_extension'
@@ -181,6 +188,9 @@ handle_RCPT_extension(Extension, _State) ->
 %% For each `ok' in the `StatusList', we have accepted full responsibility for
 %% delivering the email to that specific recipient. When a single recipient is
 %% specified the returned value can also follow the SMTP format.
+%%
+%% When the BINARYMIME extension is enabled, `Data` might contain arbitrary bytes, not
+%% necessarily UTF8.
 %%
 %% `ErrorMsg' should always start with the SMTP error code, while `SuccessMsg'
 %% should not (the `250' code is automatically prepended).


### PR DESCRIPTION
This PR implements [RFC 3030](https://datatracker.ietf.org/doc/html/rfc3030), which defines the CHUNKING and BINARYMIME extensions. 

This implementation is rather conservative in the changes it makes to gen_smtp, in particular regarding the API. 

On the server side, **by default**: 
* CHUNKING is enabled, as it is possible to fully abstract away how a message was delivered, from the PoV of a user of this library;
* BINARYMIME is disabled (unless activated in the `handle_EHLO` callback by setting it to `true`) because such messages always bypass the newline fixing and may not be UTF8, contrary to what one might reasonably expect when implementing `handle_DATA`. It is not currently possible to know whether a message was sent with this body type, should this be implemented? Feedback welcome here.

On the client side, **by default**: 
* CHUNKING (i.e., the `BDAT` command) will not be used, even if possible, **for now** (I'd like to have feedback first, but otherwise it should not be a problem to use it by default whenever possible);
* BINARYMIME will not be used, unless enabled through the options (so, session-wide -- I think it might make sense to allow setting this per-email? Feedback welcome here). 