### PR TITLE
feat: client tls_options/sockopts spec, check ssl and tls

### DIFF
--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -79,9 +79,9 @@
 -type options() :: [
     {ssl, boolean()}
     | {tls, always | never | if_available}
-    % ssl:option() / ssl:tls_client_option()
-    | {tls_options, list()}
-    | {sockopts, [gen_tcp:connect_option()]}
+    | {tls_options, [ssl:tls_client_option()]}
+    %% depending on "ssl" option
+    | {sockopts, [gen_tcp:connect_option() | ssl:tls_client_option()]}
     | {port, inet:port_number()}
     | {timeout, timeout()}
     | {relay, inet:ip_address() | inet:hostname()}
@@ -941,6 +941,9 @@ quit(Socket) ->
 
 % TODO - more checking
 check_options(Options) ->
+    SSL = proplists:get_value(ssl, Options, false),
+    TLS = proplists:get_value(tls, Options, if_available),
+    State0 = check_ssl_options(SSL, TLS),
     CheckedOptions = [relay, port, auth],
     lists:foldl(
         fun(Option, State) ->
@@ -952,9 +955,14 @@ check_options(Options) ->
                     Other
             end
         end,
-        ok,
+        State0,
         CheckedOptions
     ).
+
+check_ssl_options(true, always) ->
+    {error, requested_both_ssl_and_tls};
+check_ssl_options(_, _) ->
+    ok.
 
 check_option({relay, undefined}, _Options) ->
     {error, no_relay};


### PR DESCRIPTION
Just recently I tried to use this lib to send some mails through existing SMTP server and I've stumbled upon few things:

1. Correct me if I'm wrong, but based on [this reply](https://github.com/gen-smtp/gen_smtp/issues/298#issuecomment-1405328435) and my own experience, it's not possible to establish a connection to SMTP server when both `ssl` and `tls` options are set. We must choose only one of them. That's why I've added `chech_ssl_optionss/2` When `ssl` is set to `true` and `tls` to always I get `{missing_requirement, Host, tls}` error. When I choose only one, sending succeeds.
2. `sockopts` can be `[tls_client_options()]` when `ssl` is set to `true`. This doesn't help very much to dialyzer, but it does to the documentation.
3. `tls_options` specified more correctly (guess that those types weren't exposed when defining `gen_smtp_client:options/0` type.)