### PR TITLE
Fix an issue where gen_smtp_server_session did not compile on OTP-28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           rebar3-version: ${{ matrix.rebar3 }}
 
       - name: Cache Hex packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/rebar3/hex/hexpm/packages
           key: ${{ runner.os }}-hex-${{ hashFiles('**/rebar.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             profile: "ranch_v2"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1
         with:
@@ -40,7 +40,7 @@ jobs:
           restore-keys: ${{ runner.os }}-hex-
 
       - name: Cache Dialyzer PLTs
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/rebar3/rebar3_*_plt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        otp: ["25", "24", "23", "22"]
+        otp: ["25", "24", "23"]
         rebar3: ["3.18.0"]
         profile: [test, ranch_v2]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,6 @@ jobs:
         otp: ["25", "24", "23", "22"]
         rebar3: ["3.18.0"]
         profile: [test, ranch_v2]
-        include:
-          - os: ubuntu-22.04
-            otp: "21"
-            rebar3: "3.15.2"
-            profile: "test"
-          - os: ubuntu-22.04
-            otp: "21"
-            rebar3: "3.15.2"
-            profile: "ranch_v2"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,16 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         otp: ["25", "24", "23", "22"]
         rebar3: ["3.18.0"]
         profile: [test, ranch_v2]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             otp: "21"
             rebar3: "3.15.2"
             profile: "test"
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             otp: "21"
             rebar3: "3.15.2"
             profile: "ranch_v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        otp: ["25", "24", "23"]
+        otp: ["25", "24"]
         rebar3: ["3.18.0"]
         profile: [test, ranch_v2]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
         rebar3: ["3.18.0"] # https://www.rebar3.org
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1
         with:
@@ -29,7 +29,7 @@ jobs:
           rebar3-version: ${{ matrix.rebar3 }}
 
       - name: Cache Hex packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/rebar3/hex/hexpm/packages
           key: ${{ runner.os }}-hex-${{ hashFiles('**/rebar.lock') }}

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -571,7 +571,7 @@ handle_request(
                             }};
                         <<"CRAM-MD5">> ->
                             % ensure crypto is started, we're gonna need it
-                            crypto:start(),
+                            application:ensure_started(crypto),
                             String = smtp_util:get_cram_string(hostname(Options)),
                             send(State, ["334 ", String, "\r\n"]),
                             {ok, State#state{


### PR DESCRIPTION
Remove OTP-21, 22, and 23 from CI as they are not anymore supported by the setup-beam action.