### PR TITLE
Add `auth_method` option to `gen_smtp_client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The `send` method variants `send/2, send/3, send_blocking/2` take an `Options` a
   * **hostname** the hostname to be used by the smtp relay. Defaults to: `smtp_util:guess_FQDN()`. The hostname on your computer might not be correct, so set this to a valid value.
   * **retries** how many retries per smtp host on temporary failure. Defaults to 1, which means it will retry once if there is a failure.
   * **protocol** valid values are `smtp`, `lmtp`. Default is `smtp`
-
+  * **auth_method** valid values are `'cram-md5'`, `login`, `plain`, `xouath2`. If omitted, all methods supported by the server will be attempted in the following order: `'cram-md5'`, `login`, `plain`, `xouath2`.
 
 ### DKIM signing of outgoing emails
 

--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -66,7 +66,8 @@
     smtp_session_error/0,
     host_failure/0,
     failure/0,
-    validate_options_error/0
+    validate_options_error/0,
+    auth_method/0
 ]).
 
 -type email_address() :: string() | binary().
@@ -75,6 +76,8 @@
     To :: [email_address(), ...],
     Body :: string() | binary() | fun(() -> string() | binary())
 }.
+
+-type auth_method() :: 'cram-md5' | login | plain | xoauth2.
 
 -type options() :: [
     {ssl, boolean()}
@@ -94,6 +97,7 @@
     | {trace_fun, fun((Fmt :: string(), Args :: [any()]) -> any())}
     | {on_transaction_error, quit | reset}
     | {protocol, smtp | lmtp}
+    | {auth_method, auth_method()}
 ].
 
 -type extensions() :: [{binary(), binary()}].
@@ -623,6 +627,15 @@ to_string(Binary) when is_binary(Binary) -> binary_to_list(Binary).
 to_binary(String) when is_binary(String) -> String;
 to_binary(String) when is_list(String) -> list_to_binary(String).
 
+auth_pref(Options) ->
+    auth_pref1(proplists:get_value(auth_method, Options)).
+
+auth_pref1(undefined) -> ?AUTH_PREFERENCE;
+auth_pref1('cram-md5') -> ["CRAM-MD5"];
+auth_pref1(login) -> ["LOGIN"];
+auth_pref1(plain) -> ["PLAIN"];
+auth_pref1(xoauth2) -> ["XOAUTH2"].
+
 -spec do_AUTH(
     Socket :: smtp_socket:socket(),
     Username :: binary(),
@@ -633,7 +646,7 @@ to_binary(String) when is_list(String) -> list_to_binary(String).
 do_AUTH(Socket, Username, Password, Types, Options) ->
     FixedTypes = [string:to_upper(X) || X <- Types],
     trace(Options, "Fixed types: ~p~n", [FixedTypes]),
-    AllowedTypes = [X || X <- ?AUTH_PREFERENCE, lists:member(X, FixedTypes)],
+    AllowedTypes = [X || X <- auth_pref(Options), lists:member(X, FixedTypes)],
     trace(Options, "available authentication types, in order of preference: ~p~n", [AllowedTypes]),
     do_AUTH_each(Socket, Username, Password, AllowedTypes, Options).
 
@@ -941,7 +954,7 @@ quit(Socket) ->
 
 % TODO - more checking
 check_options(Options) ->
-    CheckedOptions = [relay, port, auth],
+    CheckedOptions = [relay, port, auth, auth_method],
     lists:foldl(
         fun(Option, State) ->
             case State of
@@ -976,7 +989,14 @@ check_option({auth, always}, Options) ->
             ok
     end;
 check_option({auth, _}, _Options) ->
-    ok.
+    ok;
+check_option({auth_method, undefined}, _Options) ->
+    ok;
+check_option({auth_method, A}, _Options) when A =:= 'cram-md5'; A =:= 'login';
+                                              A =:= 'plain'; A =:= 'xoauth2'  ->
+    ok;
+check_option({auth_method, _}, _Options) ->
+    {error, invalid_auth_method}.
 
 -spec parse_extensions(Reply :: binary(), Options :: options()) -> extensions().
 parse_extensions(Reply, Options) ->


### PR DESCRIPTION
The default hard-coded AUTH_PREFERENCE in `gen_smtp_client` results in unnecessary round trips and may significantly increase send time. 
```
-define(AUTH_PREFERENCE, [
    "CRAM-MD5",
    "LOGIN",
    "PLAIN",
    "XOAUTH2"
]).
```

For example: 
1. The client wants to use XOAUTH2 and sets OAuth token as a password option. 
2. The server supports both XOAUTH2 and LOGIN.
3. The client attempts LOGIN since it has higher preference (see code example above). However, this auth method can't succeed since the client passed OAuth token and not user password.
4. Login auth is decliend by the server and only after that XOAUTH2 is attempted and succeeded.

I've tested the above case with smtp.office365.com and `gen_smtp_client:send_blocking/2` execution time was ~7s.
When I added `auth_method` option and set it to `xoauth2` execution time dropped to ~1.5s.
Please see examples below.

Without setting `auth_method` measured time was 7292 ms:
```
timer:tc(fun() -> gen_smtp_client:send_blocking({<<"from">>,
    [<<"to">>],
    <<"body">>}, [{no_mx_lookups,true},
    {retries,3},
    {tls, always},
    {username, <<"username">>},
    {password, Token},
    {hostname, <<"hostname">>},
    {relay, <<"smtp.office365.com">>},
    {auth, always},
    {ssl, false},
    {port, 587},
    {tls_options, [{verify, verify_none},
                  {versions, ['tlsv1.3', 'tlsv1.2', 'tlsv1.1']}]},
    {trace_fun, fun(F, Args) -> io:format(F, Args) end}
    %% , {auth_method, xoauth2}
   ]) end, millisecond).
MX records for smtp.office365.com are []
connected to smtp.office365.com; ...

Extensions are [{<<"SIZE">>,<<"157286400">>},
                {<<"PIPELINING">>,true},
                {<<"DSN">>,true},
                {<<"ENHANCEDSTATUSCODES">>,true},
                {<<"STARTTLS">>,true},
                {<<"8BITMIME">>,true},
                {<<"BINARYMIME">>,true},
                {<<"CHUNKING">>,true},
                {<<"SMTPUTF8">>,true}]
Starting TLS
TLS started
Extensions are [{<<"SIZE">>,<<"157286400">>},
                {<<"PIPELINING">>,true},
                {<<"DSN">>,true},
                {<<"ENHANCEDSTATUSCODES">>,true},
                {<<"AUTH">>,<<"LOGIN XOAUTH2">>},
                {<<"8BITMIME">>,true},
                {<<"BINARYMIME">>,true},
                {<<"CHUNKING">>,true},
                {<<"SMTPUTF8">>,true}]
Auth types: <<"LOGIN XOAUTH2">>
Fixed types: ["LOGIN","XOAUTH2"]
available authentication types, in order of preference: ["LOGIN","XOAUTH2"]
username prompt
password prompt
password rejected: 535 5.7.139 Authentication unsuccessful, the request did not meet the criteria to be authenticated successfully. Contact your administrator. ...
Authentication status is true
{7292,
 <<"2.0.0 OK ..."...>>}
```

Setting `{auth_method, xoauth2}` opt resulted in decreasing the time to 1534 ms:
```
timer:tc(fun() -> gen_smtp_client:send_blocking({<<"from">>,
    [<<"to">>],
    <<"body">>}, [{no_mx_lookups,true},
    {retries,3},
    {tls, always},
    {username, <<"username">>},
    {password, Token},
    {hostname, <<"hostname">>},
    {relay, <<"smtp.office365.com">>},
    {auth, always},
    {ssl, false},
    {port, 587},
    {tls_options, [{verify, verify_none},
                  {versions, ['tlsv1.3', 'tlsv1.2', 'tlsv1.1']}]},
    {trace_fun, fun(F, Args) -> io:format(F, Args) end}
    , {auth_method, xoauth2}
   ]) end, millisecond).
MX records for smtp.office365.com are []
connected to smtp.office365.com; ...

Extensions are [{<<"SIZE">>,<<"157286400">>},
                {<<"PIPELINING">>,true},
                {<<"DSN">>,true},
                {<<"ENHANCEDSTATUSCODES">>,true},
                {<<"STARTTLS">>,true},
                {<<"8BITMIME">>,true},
                {<<"BINARYMIME">>,true},
                {<<"CHUNKING">>,true},
                {<<"SMTPUTF8">>,true}]
Starting TLS
TLS started
Extensions are [{<<"SIZE">>,<<"157286400">>},
                {<<"PIPELINING">>,true},
                {<<"DSN">>,true},
                {<<"ENHANCEDSTATUSCODES">>,true},
                {<<"AUTH">>,<<"LOGIN XOAUTH2">>},
                {<<"8BITMIME">>,true},
                {<<"BINARYMIME">>,true},
                {<<"CHUNKING">>,true},
                {<<"SMTPUTF8">>,true}]
Auth types: <<"LOGIN XOAUTH2">>
Fixed types: ["LOGIN","XOAUTH2"]
available authentication types, in order of preference: ["XOAUTH2"]
Authentication status is true
{1534,
 <<"2.0.0 OK ..."...>>}
```