### PR TITLE
fix(gen_smtp): replace deprecated catch expressions

### DIFF
--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -824,9 +824,9 @@ do_STARTTLS(Socket, Options) ->
                 {ok, NewSocket} ->
                     {ok, Extensions} = try_EHLO(NewSocket, Options),
                     {NewSocket, Extensions};
-                {'EXIT', Reason} ->
+                {'EXIT', Reason0} ->
                     quit(Socket),
-                    error_logger:error_msg("Error in ssl upgrade: ~p.~n", [Reason]),
+                    error_logger:error_msg("Error in ssl upgrade: ~p.~n", [Reason0]),
                     erlang:throw({temporary_failure, tls_failed});
                 {error, closed} ->
                     quit(Socket),

--- a/src/gen_smtp_client.erl
+++ b/src/gen_smtp_client.erl
@@ -808,13 +808,20 @@ do_STARTTLS(Socket, Options) ->
     smtp_socket:send(Socket, "STARTTLS\r\n"),
     case read_possible_multiline_reply(Socket) of
         {ok, <<"220", _Rest/binary>>} ->
-            case
-                catch smtp_socket:to_ssl_client(
-                    Socket, [binary | proplists:get_value(tls_options, Options, [])], 5000
-                )
-            of
+            SslResult =
+                try
+                    smtp_socket:to_ssl_client(
+                        Socket,
+                        [binary | proplists:get_value(tls_options, Options, [])],
+                        5000
+                    )
+                catch
+                    Class:Reason:Stacktrace ->
+                        {'EXIT', {Class, Reason, Stacktrace}}
+                end,
+
+            case SslResult of
                 {ok, NewSocket} ->
-                    %NewSocket;
                     {ok, Extensions} = try_EHLO(NewSocket, Options),
                     {NewSocket, Extensions};
                 {'EXIT', Reason} ->

--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -397,12 +397,17 @@ terminate(Reason, #state{
 -spec code_change(OldVsn :: any(), State :: #state{}, Extra :: any()) -> {'ok', #state{}}.
 code_change(OldVsn, #state{module = Module, callbackstate = CallbackState} = State, Extra) ->
     % TODO - this should probably be the callback module's version or its checksum
-    CallbackState =
-        case catch Module:code_change(OldVsn, CallbackState, Extra) of
-            {ok, NewCallbackState} -> NewCallbackState;
-            _ -> CallbackState
+    NewCallbackState =
+        try Module:code_change(OldVsn, CallbackState, Extra) of
+            {ok, UpdatedCallbackState} ->
+                UpdatedCallbackState;
+            _ ->
+                CallbackState
+        catch
+            _:_ ->
+                CallbackState
         end,
-    {ok, State#state{callbackstate = CallbackState}}.
+    {ok, State#state{callbackstate = NewCallbackState}}.
 
 -spec parse_request(Packet :: binary()) -> {binary(), binary()}.
 parse_request(Packet) ->


### PR DESCRIPTION
Replace deprecated Erlang `catch Expr` usage with explicit `try ... catch ... end` blocks in STARTTLS upgrade and callback code_change handling.

Also avoid rebinding the existing callback state variable by assigning the result to NewCallbackState before updating the session state.